### PR TITLE
Allow multi-line secrets and increase the linter timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ run:
   concurrency: 4
 
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
+  timeout: 10m
 linters-settings:
   govet:
     check-shadowing: true

--- a/dp-legacy-cache-proxy.nomad
+++ b/dp-legacy-cache-proxy.nomad
@@ -67,7 +67,7 @@ job "dp-legacy-cache-proxy" {
         # Secret configs read from vault
         {{ with (secret (print "secret/" (env "NOMAD_TASK_NAME"))) }}
         {{ range $key, $value := .Data }}
-        export {{ $key }}="{{ $value }}"
+        export {{ $key }}={{ $value | toJSON }}
         {{ end }}
         {{ end }}
         EOH


### PR DESCRIPTION
### What

Changed the Nomad config to allow multi-line secrets, in the same way it's been done in the legacy API: https://github.com/ONSdigital/dp-legacy-cache-api/pull/14

The linter timeout has been increased as well, as we've noticed intermittent failures in the pipeline before due to this.

### How to review

Linden or Geraint may be able to provide more context, as they were the ones who created the original fix in the API.

### Who can review

Anyone.