### PR TITLE
Fail test suite when there are pending or undefined steps

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -53,6 +53,7 @@ func TestComponent(t *testing.T) {
 			Output: colors.Colored(os.Stdout),
 			Format: "pretty",
 			Paths:  flag.Args(),
+			Strict: true,
 		}
 
 		f := &ComponentTest{}


### PR DESCRIPTION
### What

Currently, when a Godog step is missing, a warning is issued, and a step (and scenario) is marked as undefined when running the component tests. However, the exit code is still 0, which means that the pipeline will not fail when a step is undefined. This means that a malformed step could inadvertently make a whole scenario to go untested, and the Component Test pipeline job would still pass.

As part of this change, we're changing this behaviour, so that the exit code is not 0 when a step is pending or undefined.

### How to review

Deliberately introduce an error in one of the existing features, so that one of the Given/When/Then lines cannot be matched with an existing step. Run `make test-component`. See how a warning is displayed in the logs, but the exit code (`echo $?`) is not 0. If you remove `Strict: true` from the Godog configuration (which was the previous behaviour), the exit code is 0.

### Who can review

Anyone.