### PR TITLE
Fix the "/health" endpoint being unavailable

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -18,7 +18,7 @@ func Setup(ctx context.Context, r *mux.Router, babbageURL string) *Proxy {
 		Router: r,
 	}
 
-	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	r.PathPrefix("/").Name("Proxy Catch-All").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		proxy.manage(ctx, w, req, babbageURL)
 	})
 	return proxy

--- a/service/service.go
+++ b/service/service.go
@@ -38,8 +38,6 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 
 	// TODO: Add other(s) to serviceList here
 
-	p := proxy.Setup(ctx, r, cfg.BabbageURL)
-
 	hc, err := serviceList.GetHealthCheck(cfg, buildTime, gitCommit, version)
 
 	if err != nil {
@@ -52,6 +50,11 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	}
 
 	r.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)
+
+	// The proxy needs to be set up after the HealthCheck route has been added to the router: in the Setup method, the
+	// proxy adds a catch-all route, so any other routes added after that one will never be reachable.
+	p := proxy.Setup(ctx, r, cfg.BabbageURL)
+
 	hc.Start(ctx)
 
 	// Run the http server in a new go-routine


### PR DESCRIPTION
### What

The proxy has a catch-all route that redirects all incoming requests to Babbage. This means that requests to the "/health" route are being incorrectly sent to Babbage. This PR fixes this, making the Health Checker reachable again. I've added a test to ensure that this type of problem does not happen again in the future, if some other new routes are added.

### How to review

Run it locally and observe how the "/health" endpoint returns a healthy response as expected.

### Who can review

Anyone.
