### PR TITLE
Implement the long cache time scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Proxy for handling the cache for pages within the legacy CMS
 | OTEL_EXPORTER_OTLP_ENDPOINT  | localhost:4317        | OpenTelemetry Exporter address                                                                                     |
 | OTEL_SERVICE_NAME            | dp-legacy-cache-proxy | The name of this service in OpenTelemetry                                                                          |
 | BABBAGE_URL                  | http://localhost:8080 | Babbage address, where all the incoming requests are forwarded to                                                  |
+| CACHE_TIME_DEFAULT           | 15m                   | Default value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                   |
+| CACHE_TIME_ERRORED           | 30s                   | Errored value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                   |
+| CACHE_TIME_LONG              | 4h                    | Long value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                      |
+| CACHE_TIME_SHORT             | 10s                   | Short value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                     |
 
 ### Contributing
 

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,10 @@ type Config struct {
 	OTExporterOTLPEndpoint     string        `envconfig:"OTEL_EXPORTER_OTLP_ENDPOINT"`
 	OTServiceName              string        `envconfig:"OTEL_SERVICE_NAME"`
 	BabbageURL                 string        `envconfig:"BABBAGE_URL"`
+	CacheTimeDefault           time.Duration `envconfig:"CACHE_TIME_DEFAULT"`
+	CacheTimeErrored           time.Duration `envconfig:"CACHE_TIME_ERRORED"`
+	CacheTimeLong              time.Duration `envconfig:"CACHE_TIME_LONG"`
+	CacheTimeShort             time.Duration `envconfig:"CACHE_TIME_SHORT"`
 }
 
 var cfg *Config
@@ -36,6 +40,10 @@ func Get() (*Config, error) {
 		OTExporterOTLPEndpoint:     "localhost:4317",
 		OTServiceName:              "dp-legacy-cache-proxy",
 		BabbageURL:                 "http://localhost:8080",
+		CacheTimeDefault:           15 * time.Minute,
+		CacheTimeErrored:           30 * time.Second,
+		CacheTimeLong:              4 * time.Hour,
+		CacheTimeShort:             10 * time.Second,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,6 +31,10 @@ func TestConfig(t *testing.T) {
 					OTExporterOTLPEndpoint:     "localhost:4317",
 					OTServiceName:              "dp-legacy-cache-proxy",
 					BabbageURL:                 "http://localhost:8080",
+					CacheTimeDefault:           15 * time.Minute,
+					CacheTimeErrored:           30 * time.Second,
+					CacheTimeLong:              4 * time.Hour,
+					CacheTimeShort:             10 * time.Second,
 				})
 			})
 

--- a/features/configured_cache_time.feature
+++ b/features/configured_cache_time.feature
@@ -3,17 +3,39 @@ Feature: Configured cache time
   The proxy may alter the Cache-Control header in the Babbage response in order to set the "max-age" value to one of
   four preconfigured values: short, long, errored or default cache time.
 
-  Scenario Outline: Versioned path should have a long cache time
+  Background:
     Given Babbage will send the following response:
       """
       Mock response from Babbage
       """
-    When the Proxy receives a GET request for "<versioned-path>"
-    Then the response header "Cache-Control" should be "max-age=42"
+
+  Scenario Outline: Versioned URI should have a long cache time
+    When the Proxy receives a GET request for "<versioned-uri>"
+    Then the response header "Cache-Control" should be "max-age=14400"
   Examples:
-    | versioned-path                                                                                                                                                                          |
+    | versioned-uri                                                                                                                                                                           |
     | /economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1                                                                                              |
     | /chartimage?uri=economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1/30d7d6c2                                                                      |
     | /economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1/30d7d6c2/data                                                                                |
     | /file?uri=/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpilemindicesandpricequotes/pricequotesseptember2023/previous/v1/pricequotes202309.xlsx |
     | /file?uri=/economy/inflationandpriceindices/datasets/consumerpriceindices/current/previous/v103/mm23.csv                                                                                |
+
+  Scenario Outline: ONS URI should have a long cache time
+    When the Proxy receives a GET request for "<ons-uri>"
+    Then the response header "Cache-Control" should be "max-age=14400"
+  Examples:
+    | ons-uri                                                                                    |
+    | /ons/rel/household-income/the-effects-of-taxes-and-benefits-on-household-income/index.html |
+    | /ons/rel/integrated-household-survey/integrated-household-survey/index.html                |
+
+  Scenario Outline: Legacy asset URI should have a long cache time
+    When the Proxy receives a GET request for "<legacy-asset-uri>"
+    Then the response header "Cache-Control" should be "max-age=14400"
+  Examples:
+    | legacy-asset-uri                                        |
+    | /img/national-statistics.png                            |
+    | /css/main.css                                           |
+    | /scss/some-sass-file.scss                               |
+    | /js/app.js                                              |
+    | /fonts/open-sans-regular/OpenSans-Regular-webfont.woff2 |
+    | /favicon.ico                                            |

--- a/features/steps/proxy_component.go
+++ b/features/steps/proxy_component.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
@@ -98,5 +99,23 @@ func (c *Component) DoGetHTTPServer(bindAddr string, router http.Handler) servic
 }
 
 func (c *Component) DoGetRequestMiddleware() service.RequestMiddleware {
-	return &service.HTTPTestRequestMiddleware{}
+	return &HTTPTestRequestMiddleware{}
+}
+
+type HTTPTestRequestMiddleware struct{}
+
+func (rm HTTPTestRequestMiddleware) GetMiddlewareFunction() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// The APIFeature in dp-component-test appends "http://foo" to the request. In production, the scheme and
+			// host are not set. This middleware removes them, so that the request looks like it would in production.
+			r.URL.Scheme = ""
+			r.URL.Host = ""
+
+			requestURI, _ := strings.CutPrefix(r.RequestURI, "http://foo")
+			r.RequestURI = requestURI
+
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/proxy/manager.go
+++ b/proxy/manager.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
 	"github.com/ONSdigital/dp-legacy-cache-proxy/response"
 	"github.com/ONSdigital/log.go/v2/log"
 )
 
-func (proxy *Proxy) manage(ctx context.Context, w http.ResponseWriter, req *http.Request, babbageURL string) {
-	targetURL := babbageURL + req.URL.String()
+func (proxy *Proxy) manage(ctx context.Context, w http.ResponseWriter, req *http.Request, cfg *config.Config) {
+	targetURL := cfg.BabbageURL + req.URL.String()
 
 	proxyReq, err := http.NewRequestWithContext(ctx, req.Method, targetURL, req.Body)
 
@@ -37,5 +38,5 @@ func (proxy *Proxy) manage(ctx context.Context, w http.ResponseWriter, req *http
 		}
 	}()
 
-	response.WriteResponse(ctx, w, babbageResponse, req)
+	response.WriteResponse(ctx, w, babbageResponse, req, cfg)
 }

--- a/proxy/manager_test.go
+++ b/proxy/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
 	"github.com/ONSdigital/dp-legacy-cache-proxy/proxy"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
@@ -25,9 +26,9 @@ func TestProxyHandleRequestOK(t *testing.T) {
 
 		ctx := context.Background()
 		router := mux.NewRouter()
-		babbageURL := mockBabbageServer.URL
+		cfg := &config.Config{BabbageURL: mockBabbageServer.URL}
 
-		legacyCacheProxy := proxy.Setup(ctx, router, babbageURL)
+		legacyCacheProxy := proxy.Setup(ctx, router, cfg)
 
 		Convey("When a request is sent", func() {
 			w := httptest.NewRecorder()
@@ -47,7 +48,8 @@ func TestProxyHandleRequestError(t *testing.T) {
 	Convey("Given a Proxy with an invalid Babbage URL configuration", t, func() {
 		ctx := context.Background()
 		router := mux.NewRouter()
-		legacyCacheProxy := proxy.Setup(ctx, router, "invalid-babbage-url")
+		cfg := &config.Config{BabbageURL: "invalid-babbage-url"}
+		legacyCacheProxy := proxy.Setup(ctx, router, cfg)
 
 		Convey("When a request is sent", func() {
 			w := httptest.NewRecorder()

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
 	"github.com/gorilla/mux"
 )
 
@@ -13,13 +14,13 @@ type Proxy struct {
 }
 
 // Setup function sets up the proxy and returns a Proxy
-func Setup(ctx context.Context, r *mux.Router, babbageURL string) *Proxy {
+func Setup(ctx context.Context, r *mux.Router, cfg *config.Config) *Proxy {
 	proxy := &Proxy{
 		Router: r,
 	}
 
 	r.PathPrefix("/").Name("Proxy Catch-All").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		proxy.manage(ctx, w, req, babbageURL)
+		proxy.manage(ctx, w, req, cfg)
 	})
 	return proxy
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
 	"github.com/ONSdigital/dp-legacy-cache-proxy/proxy"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
@@ -15,8 +16,8 @@ func TestSetup(t *testing.T) {
 	Convey("Given a Proxy instance", t, func() {
 		r := mux.NewRouter()
 		ctx := context.Background()
-		babbageURL := "mock-babbage-url"
-		legacyCacheProxy := proxy.Setup(ctx, r, babbageURL)
+		cfg := &config.Config{}
+		legacyCacheProxy := proxy.Setup(ctx, r, cfg)
 
 		Convey("When created, all HTTP methods should be accepted", func() {
 			So(hasRoute(legacyCacheProxy.Router, "/", http.MethodGet), ShouldBeTrue)

--- a/response/max_age.go
+++ b/response/max_age.go
@@ -2,12 +2,43 @@ package response
 
 import (
 	"context"
+	"regexp"
+	"strings"
 
+	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
 	"github.com/ONSdigital/log.go/v2/log"
 )
 
-func maxAge(ctx context.Context, path string) int {
-	log.Info(ctx, "Calculating max-age for "+path)
-	// TODO To be implemented as part of DIS-411
-	return 42
+var versionedURIRegexp = regexp.MustCompile(`/previous/v\d+`)
+
+func maxAge(ctx context.Context, uri string, cfg *config.Config) int {
+	log.Info(ctx, "Calculating max-age for "+uri)
+
+	if isLegacyAssetURI(uri) || isOnsURI(uri) || isVersionedURI(uri) {
+		return int(cfg.CacheTimeLong.Seconds())
+	}
+
+	return int(cfg.CacheTimeDefault.Seconds())
+}
+
+func isLegacyAssetURI(uri string) bool {
+	legacyAssetFolders := []string{"/img/", "/css/", "/scss/", "/js/", "/fonts/"}
+
+	for _, folder := range legacyAssetFolders {
+		if strings.HasPrefix(uri, folder) {
+			return true
+		}
+	}
+
+	return uri == "/favicon.ico"
+}
+
+func isOnsURI(uri string) bool {
+	return strings.HasPrefix(uri, "/ons/")
+}
+
+func isVersionedURI(uri string) bool {
+	matched := versionedURIRegexp.MatchString(uri)
+
+	return matched
 }

--- a/response/max_age_test.go
+++ b/response/max_age_test.go
@@ -1,0 +1,74 @@
+package response
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type TestCase struct {
+	cacheTime int
+	uri       string
+}
+
+func TestMaxAge(t *testing.T) {
+	Convey("Given a list of URIs and some pre-configured cache time values", t, func() {
+		ctx := context.Background()
+		defaultCacheTime := 100
+		longCacheTime := 9999
+		cfg := &config.Config{
+			CacheTimeDefault: time.Duration(defaultCacheTime) * time.Second,
+			CacheTimeLong:    time.Duration(longCacheTime) * time.Second,
+		}
+
+		versionedURIs := []TestCase{
+			{longCacheTime, "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1"},
+			{longCacheTime, "/chartimage?uri=economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1/30d7d6c2"},
+			{longCacheTime, "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1/30d7d6c2/data"},
+			{longCacheTime, "/file?uri=/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpilemindicesandpricequotes/pricequotesseptember2023/previous/v1/pricequotes202309.xlsx"},
+			{longCacheTime, "/file?uri=/economy/inflationandpriceindices/datasets/consumerpriceindices/current/previous/v103/mm23.csv"},
+		}
+
+		onsURIs := []TestCase{
+			{longCacheTime, "/ons/rel/household-income/the-effects-of-taxes-and-benefits-on-household-income/index.html"},
+			{longCacheTime, "/ons/rel/integrated-household-survey/integrated-household-survey/index.html"},
+		}
+
+		legacyAssetURIs := []TestCase{
+			{longCacheTime, "/img/national-statistics.png"},
+			{longCacheTime, "/css/main.css"},
+			{longCacheTime, "/scss/some-sass-file.scss"},
+			{longCacheTime, "/js/app.js"},
+			{longCacheTime, "/fonts/open-sans-regular/OpenSans-Regular-webfont.woff2"},
+			{longCacheTime, "/favicon.ico"},
+		}
+
+		regularURIs := []TestCase{
+			{defaultCacheTime, "/this-uri/does-not-fall-into-any-special-category"},
+			{defaultCacheTime, "/employmentandlabourmarket"},
+		}
+
+		groupedTestCases := [][]TestCase{
+			versionedURIs,
+			onsURIs,
+			legacyAssetURIs,
+			regularURIs,
+		}
+
+		Convey("When the 'maxAge' function is called", func() {
+			for _, testCases := range groupedTestCases {
+				for _, tc := range testCases {
+					result := maxAge(ctx, tc.uri, cfg)
+
+					Convey(fmt.Sprintf(`Then it should return a cache time of %d seconds for the following URI: %q`, tc.cacheTime, tc.uri), func() {
+						So(result, ShouldEqual, tc.cacheTime)
+					})
+				}
+			}
+		})
+	})
+}

--- a/response/writer.go
+++ b/response/writer.go
@@ -6,10 +6,11 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
 	"github.com/ONSdigital/log.go/v2/log"
 )
 
-func WriteResponse(ctx context.Context, w http.ResponseWriter, babbageResponse *http.Response, req *http.Request) {
+func WriteResponse(ctx context.Context, w http.ResponseWriter, babbageResponse *http.Response, req *http.Request, cfg *config.Config) {
 	if !isGetOrHead(req.Method) {
 		writeUnmodifiedResponse(ctx, w, babbageResponse)
 	} else if !isCacheableStatusCode(babbageResponse.StatusCode) {
@@ -17,7 +18,7 @@ func WriteResponse(ctx context.Context, w http.ResponseWriter, babbageResponse *
 	} else if cacheControl := babbageResponse.Header.Get("Cache-Control"); !shouldCalculateMaxAge(cacheControl) {
 		writeUnmodifiedResponse(ctx, w, babbageResponse)
 	} else {
-		maxAgeInSeconds := maxAge(ctx, req.URL.Path)
+		maxAgeInSeconds := maxAge(ctx, req.RequestURI, cfg)
 		writeResponseWithMaxAge(ctx, w, babbageResponse, maxAgeInSeconds)
 	}
 }

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -1,27 +1,14 @@
 package service
 
-import "net/http"
+import (
+	"net/http"
+)
 
 type NoOpRequestMiddleware struct{}
 
 func (rm NoOpRequestMiddleware) GetMiddlewareFunction() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r)
-		})
-	}
-}
-
-type HTTPTestRequestMiddleware struct{}
-
-func (rm HTTPTestRequestMiddleware) GetMiddlewareFunction() func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// The APIFeature in dp-component-test appends "http://foo" to the request. In production, the scheme and
-			// host are not set. This middleware removes them, so that the request looks like it would in production.
-			r.URL.Scheme = ""
-			r.URL.Host = ""
-
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -53,7 +53,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 
 	// The proxy needs to be set up after the HealthCheck route has been added to the router: in the Setup method, the
 	// proxy adds a catch-all route, so any other routes added after that one will never be reachable.
-	p := proxy.Setup(ctx, r, cfg.BabbageURL)
+	p := proxy.Setup(ctx, r, cfg)
 
 	hc.Start(ctx)
 


### PR DESCRIPTION
### What

Implemented all the different scenarios in which the Proxy should modify the Cache-Control header in the Babbage response and set the `max-age` directive to a long cache time (4 hours).

The cache time has been set as an environment variable. I have also set the environment variables for the other 3 values that will be needed as part of DIS-412.

### How to review

Examine the diagram linked in DIS-411 and ensure that this PR implements it.

### Who can review

Anyone at ONS.
