### PR TITLE
move the test fixtures out of production code, into test code

### DIFF
--- a/features/steps/proxy_component.go
+++ b/features/steps/proxy_component.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
@@ -98,5 +99,23 @@ func (c *Component) DoGetHTTPServer(bindAddr string, router http.Handler) servic
 }
 
 func (c *Component) DoGetRequestMiddleware() service.RequestMiddleware {
-	return &service.HTTPTestRequestMiddleware{}
+	return &HTTPTestRequestMiddleware{}
+}
+
+type HTTPTestRequestMiddleware struct{}
+
+func (rm HTTPTestRequestMiddleware) GetMiddlewareFunction() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// The APIFeature in dp-component-test appends "http://foo" to the request. In production, the scheme and
+			// host are not set. This middleware removes them, so that the request looks like it would in production.
+			r.URL.Scheme = ""
+			r.URL.Host = ""
+
+			requestURI, _ := strings.CutPrefix(r.RequestURI, "http://foo")
+			r.RequestURI = requestURI
+
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"net/http"
-	"strings"
 )
 
 type NoOpRequestMiddleware struct{}
@@ -10,24 +9,6 @@ type NoOpRequestMiddleware struct{}
 func (rm NoOpRequestMiddleware) GetMiddlewareFunction() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r)
-		})
-	}
-}
-
-type HTTPTestRequestMiddleware struct{}
-
-func (rm HTTPTestRequestMiddleware) GetMiddlewareFunction() func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// The APIFeature in dp-component-test appends "http://foo" to the request. In production, the scheme and
-			// host are not set. This middleware removes them, so that the request looks like it would in production.
-			r.URL.Scheme = ""
-			r.URL.Host = ""
-
-			requestURI, _ := strings.CutPrefix(r.RequestURI, "http://foo")
-			r.RequestURI = requestURI
-
 			next.ServeHTTP(w, r)
 		})
 	}


### PR DESCRIPTION
### What

having test code in non-`_test.go` files should be avoided

this is a quick Spike to see if moving that test code into the component test files would work - `make test test-component` worked for me

_caveat emptor_

### How to review

as above

### Who can review

@jmgq 
