### PR TITLE
Calculate max-age based on the response from dp-legacy-cache-api

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,6 +93,11 @@ issues:
       linters:
         - revive
       source: "github.com/smartystreets/goconvey/convey"
+    # Allow md5 usage, as it's used for hashing, not for cryptography
+    - path: (release_time|legacy_cache_api_feature).go
+      text: "weak cryptographic primitive"
+      linters:
+        - gosec
   new: false
 
 # golangci.com configuration

--- a/README.md
+++ b/README.md
@@ -12,20 +12,22 @@ Proxy for handling the cache for pages within the legacy CMS
 
 ### Configuration
 
-| Environment variable         | Default               | Description                                                                                                        |
-|------------------------------|-----------------------|--------------------------------------------------------------------------------------------------------------------|
-| BIND_ADDR                    | :29200                | The host and port to bind to                                                                                       |
-| GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                    | The graceful shutdown timeout in seconds (`time.Duration` format)                                                  |
-| HEALTHCHECK_INTERVAL         | 30s                   | Time between self-healthchecks (`time.Duration` format)                                                            |
-| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                   | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format) |
-| OTEL_BATCH_TIMEOUT           | 5s                    | Time duration after which a batch will be sent regardless of size (`time.Duration` format)                         |
-| OTEL_EXPORTER_OTLP_ENDPOINT  | localhost:4317        | OpenTelemetry Exporter address                                                                                     |
-| OTEL_SERVICE_NAME            | dp-legacy-cache-proxy | The name of this service in OpenTelemetry                                                                          |
-| BABBAGE_URL                  | http://localhost:8080 | Babbage address, where all the incoming requests are forwarded to                                                  |
-| CACHE_TIME_DEFAULT           | 15m                   | Default value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                   |
-| CACHE_TIME_ERRORED           | 30s                   | Errored value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                   |
-| CACHE_TIME_LONG              | 4h                    | Long value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                      |
-| CACHE_TIME_SHORT             | 10s                   | Short value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                     |
+| Environment variable         | Default                | Description                                                                                                                             |
+|------------------------------|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| BIND_ADDR                    | :29200                 | The host and port to bind to                                                                                                            |
+| GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                     | The graceful shutdown timeout in seconds (`time.Duration` format)                                                                       |
+| HEALTHCHECK_INTERVAL         | 30s                    | Time between self-healthchecks (`time.Duration` format)                                                                                 |
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                    | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)                      |
+| OTEL_BATCH_TIMEOUT           | 5s                     | Time duration after which a batch will be sent regardless of size (`time.Duration` format)                                              |
+| OTEL_EXPORTER_OTLP_ENDPOINT  | localhost:4317         | OpenTelemetry Exporter address                                                                                                          |
+| OTEL_SERVICE_NAME            | dp-legacy-cache-proxy  | The name of this service in OpenTelemetry                                                                                               |
+| BABBAGE_URL                  | http://localhost:8080  | Babbage address, where all the incoming requests are forwarded to                                                                       |
+| LEGACY_CACHE_API_URL         | http://localhost:29100 | Legacy Cache API address                                                                                                                |
+| CACHE_TIME_DEFAULT           | 15m                    | Default value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                                        |
+| CACHE_TIME_ERRORED           | 30s                    | Errored value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                                        |
+| CACHE_TIME_LONG              | 4h                     | Long value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                                           |
+| CACHE_TIME_SHORT             | 10s                    | Short value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                                          |
+| PUBLISH_EXPIRY_OFFSET        | 3m                     | Period of time prior to a release in which the proxy needs to return a short value for the `max-age` directive (`time.Duration` format) |
 
 ### Contributing
 

--- a/config/config.go
+++ b/config/config.go
@@ -16,10 +16,12 @@ type Config struct {
 	OTExporterOTLPEndpoint     string        `envconfig:"OTEL_EXPORTER_OTLP_ENDPOINT"`
 	OTServiceName              string        `envconfig:"OTEL_SERVICE_NAME"`
 	BabbageURL                 string        `envconfig:"BABBAGE_URL"`
+	LegacyCacheAPIURL          string        `envconfig:"LEGACY_CACHE_API_URL"`
 	CacheTimeDefault           time.Duration `envconfig:"CACHE_TIME_DEFAULT"`
 	CacheTimeErrored           time.Duration `envconfig:"CACHE_TIME_ERRORED"`
 	CacheTimeLong              time.Duration `envconfig:"CACHE_TIME_LONG"`
 	CacheTimeShort             time.Duration `envconfig:"CACHE_TIME_SHORT"`
+	PublishExpiryOffset        time.Duration `envconfig:"PUBLISH_EXPIRY_OFFSET"`
 }
 
 var cfg *Config
@@ -40,10 +42,12 @@ func Get() (*Config, error) {
 		OTExporterOTLPEndpoint:     "localhost:4317",
 		OTServiceName:              "dp-legacy-cache-proxy",
 		BabbageURL:                 "http://localhost:8080",
+		LegacyCacheAPIURL:          "http://localhost:29100",
 		CacheTimeDefault:           15 * time.Minute,
 		CacheTimeErrored:           30 * time.Second,
 		CacheTimeLong:              4 * time.Hour,
 		CacheTimeShort:             10 * time.Second,
+		PublishExpiryOffset:        3 * time.Minute,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,10 +31,12 @@ func TestConfig(t *testing.T) {
 					OTExporterOTLPEndpoint:     "localhost:4317",
 					OTServiceName:              "dp-legacy-cache-proxy",
 					BabbageURL:                 "http://localhost:8080",
+					LegacyCacheAPIURL:          "http://localhost:29100",
 					CacheTimeDefault:           15 * time.Minute,
 					CacheTimeErrored:           30 * time.Second,
 					CacheTimeLong:              4 * time.Hour,
 					CacheTimeShort:             10 * time.Second,
+					PublishExpiryOffset:        3 * time.Minute,
 				})
 			})
 

--- a/features/set_cache_time.feature
+++ b/features/set_cache_time.feature
@@ -1,7 +1,8 @@
-Feature: Configured cache time
+Feature: Set cache time
 
-  The proxy may alter the Cache-Control header in the Babbage response in order to set the "max-age" value to one of
-  four preconfigured values: short, long, errored or default cache time.
+  The proxy may alter the Cache-Control header in the Babbage response in order to set the "max-age" directive to one of
+  four preconfigured values: short, long, errored or default cache time. It may also be set to a calculated value if
+  it is a page that is about to be released.
 
   Background:
     Given Babbage will send the following response:
@@ -39,3 +40,38 @@ Feature: Configured cache time
     | /js/app.js                                              |
     | /fonts/open-sans-regular/OpenSans-Regular-webfont.woff2 |
     | /favicon.ico                                            |
+
+  Scenario: Return the errored cache time when the Legacy Cache API returns an error
+    Given the Legacy Cache API has an error
+    When the Proxy receives a GET request for "/some-path"
+    Then the response header "Cache-Control" should be "max-age=30"
+
+  Scenario: Return the default cache time when the Legacy Cache API does not have the requested page
+    Given the Legacy Cache API does not have any data for the "/some-path" page
+    When the Proxy receives a GET request for "/some-path"
+    Then the response header "Cache-Control" should be "max-age=900"
+
+  Scenario: Return the default cache time when the release time is missing
+    Given the "/some-path" page does not have a release time
+    When the Proxy receives a GET request for "/some-path"
+    Then the response header "Cache-Control" should be "max-age=900"
+
+  Scenario: Return the calculated cache time when the release time is in the near future
+    Given the "/some-path" page will have a release in the near future
+    When the Proxy receives a GET request for "/some-path"
+    Then the max-age directive should be calculated, rather than predefined
+
+  Scenario: Return the default cache time when the release time is in the distant future
+    Given the "/some-path" page will have a release in the distant future
+    When the Proxy receives a GET request for "/some-path"
+    Then the response header "Cache-Control" should be "max-age=900"
+
+  Scenario: Return the default cache time when the page was released long ago
+    Given the "/some-path" page was released long ago
+    When the Proxy receives a GET request for "/some-path"
+    Then the response header "Cache-Control" should be "max-age=900"
+
+  Scenario: Return the short cache time when the page was released recently
+    Given the "/some-path" page was released recently
+    When the Proxy receives a GET request for "/some-path"
+    Then the response header "Cache-Control" should be "max-age=10"

--- a/features/steps/legacy_cache_api_feature.go
+++ b/features/steps/legacy_cache_api_feature.go
@@ -1,0 +1,136 @@
+package steps
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/cucumber/godog"
+	"github.com/gorilla/mux"
+)
+
+type LegacyCacheAPIFeature struct {
+	Server     *httptest.Server
+	statusCode int
+	db         map[string]string
+}
+
+func NewLegacyCacheAPIFeature() *LegacyCacheAPIFeature {
+	f := LegacyCacheAPIFeature{
+		statusCode: 0,
+		db:         make(map[string]string),
+	}
+
+	router := mux.NewRouter()
+	router.HandleFunc("/v1/cache-times/{id}", func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		id := vars["id"]
+		cacheTimeResource := f.db[id]
+
+		// Set the status code if it hasn't been set already
+		if f.statusCode == 0 {
+			if cacheTimeResource == "" {
+				f.statusCode = http.StatusNotFound
+			} else {
+				f.statusCode = http.StatusOK
+			}
+		}
+
+		w.WriteHeader(f.statusCode)
+
+		if _, err := w.Write([]byte(cacheTimeResource)); err != nil {
+			panic(err)
+		}
+	}).Methods(http.MethodGet)
+
+	f.Server = httptest.NewServer(router)
+
+	return &f
+}
+
+func (f *LegacyCacheAPIFeature) Reset() {
+	f.statusCode = 0
+	f.db = make(map[string]string)
+}
+
+func (f *LegacyCacheAPIFeature) RegisterSteps(ctx *godog.ScenarioContext) {
+	ctx.Step(`^the Legacy Cache API has an error$`, f.theLegacyCacheAPIHasAnError)
+	ctx.Step(`^the Legacy Cache API does not have any data for the "([^"]*)" page$`, f.theLegacyCacheAPIDoesNotHaveAnyDataForThePage)
+	ctx.Step(`^the "([^"]*)" page does not have a release time$`, f.thePageDoesNotHaveAReleaseTime)
+	ctx.Step(`^the "([^"]*)" page will have a release in the near future$`, f.thePageWillHaveAReleaseInTheNearFuture)
+	ctx.Step(`^the "([^"]*)" page will have a release in the distant future$`, f.thePageWillHaveAReleaseInTheDistantFuture)
+	ctx.Step(`^the "([^"]*)" page was released long ago$`, f.thePageWasReleasedLongAgo)
+	ctx.Step(`^the "([^"]*)" page was released recently$`, f.thePageWasReleasedRecently)
+}
+
+func (f *LegacyCacheAPIFeature) theLegacyCacheAPIHasAnError() error {
+	f.statusCode = http.StatusInternalServerError
+
+	return nil
+}
+
+func (f *LegacyCacheAPIFeature) theLegacyCacheAPIDoesNotHaveAnyDataForThePage(path string) error {
+	delete(f.db, getID(path))
+
+	return nil
+}
+
+func (f *LegacyCacheAPIFeature) thePageDoesNotHaveAReleaseTime(path string) error {
+	f.upsertCacheTimeResource(path, time.Time{})
+
+	return nil
+}
+
+func (f *LegacyCacheAPIFeature) thePageWillHaveAReleaseInTheNearFuture(path string) error {
+	releaseTime := time.Now().Add(5 * time.Second)
+	f.upsertCacheTimeResource(path, releaseTime)
+
+	return nil
+}
+
+func (f *LegacyCacheAPIFeature) thePageWillHaveAReleaseInTheDistantFuture(path string) error {
+	releaseTime := time.Now().Add(999999 * time.Hour)
+	f.upsertCacheTimeResource(path, releaseTime)
+
+	return nil
+}
+
+func (f *LegacyCacheAPIFeature) thePageWasReleasedLongAgo(path string) error {
+	releaseTime, err := time.Parse(time.DateOnly, "1980-01-01")
+	if err != nil {
+		return err
+	}
+
+	f.upsertCacheTimeResource(path, releaseTime)
+
+	return nil
+}
+
+func (f *LegacyCacheAPIFeature) thePageWasReleasedRecently(path string) error {
+	releaseTime := time.Now().Add(-1 * time.Second)
+	f.upsertCacheTimeResource(path, releaseTime)
+
+	return nil
+}
+
+func getID(path string) string {
+	pathHash := md5.Sum([]byte(path))
+	return hex.EncodeToString(pathHash[:])
+}
+
+func generateCacheTimeResource(path string, releaseTime time.Time) string {
+	id := getID(path)
+
+	if releaseTime.IsZero() {
+		return fmt.Sprintf(`{"_id": %q, "path": %q}`, id, path)
+	}
+
+	return fmt.Sprintf(`{"_id": %q, "path": %q, "release_time": %q}`, id, path, releaseTime.Format(time.RFC3339))
+}
+
+func (f *LegacyCacheAPIFeature) upsertCacheTimeResource(path string, releaseTime time.Time) {
+	f.db[getID(path)] = generateCacheTimeResource(path, releaseTime)
+}

--- a/response/max_age.go
+++ b/response/max_age.go
@@ -2,8 +2,11 @@ package response
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -16,6 +19,40 @@ func maxAge(ctx context.Context, uri string, cfg *config.Config) int {
 
 	if isLegacyAssetURI(uri) || isOnsURI(uri) || isVersionedURI(uri) {
 		return int(cfg.CacheTimeLong.Seconds())
+	}
+
+	pagePath := getPagePath(ctx, uri)
+
+	releaseTime, statusCode, err := getReleaseTime(pagePath, cfg.LegacyCacheAPIURL)
+	if err != nil {
+		log.Error(ctx, "error calculating the max-age directive", err)
+		return int(cfg.CacheTimeErrored.Seconds())
+	}
+
+	if statusCode == http.StatusNotFound {
+		return int(cfg.CacheTimeDefault.Seconds())
+	}
+
+	if statusCode != http.StatusOK {
+		unexpectedStatusCodeError := fmt.Errorf("unexpected Legacy Cache API status code: %d", statusCode)
+		log.Error(ctx, "error calculating the max-age directive", unexpectedStatusCodeError)
+		return int(cfg.CacheTimeErrored.Seconds())
+	}
+
+	if releaseTime.IsZero() {
+		return int(cfg.CacheTimeDefault.Seconds())
+	}
+
+	if releaseTime.After(time.Now()) {
+		if calculatedCacheTime := time.Until(releaseTime); calculatedCacheTime < cfg.CacheTimeDefault {
+			return int(calculatedCacheTime.Seconds())
+		}
+
+		return int(cfg.CacheTimeDefault.Seconds())
+	}
+
+	if wasReleasedRecently(releaseTime, cfg.PublishExpiryOffset) {
+		return int(cfg.CacheTimeShort.Seconds())
 	}
 
 	return int(cfg.CacheTimeDefault.Seconds())
@@ -38,7 +75,9 @@ func isOnsURI(uri string) bool {
 }
 
 func isVersionedURI(uri string) bool {
-	matched := versionedURIRegexp.MatchString(uri)
+	return versionedURIRegexp.MatchString(uri)
+}
 
-	return matched
+func wasReleasedRecently(releaseTime time.Time, offset time.Duration) bool {
+	return releaseTime.Add(offset).After(time.Now())
 }

--- a/response/max_age_test.go
+++ b/response/max_age_test.go
@@ -3,6 +3,8 @@ package response
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -10,65 +12,188 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-type TestCase struct {
-	cacheTime int
-	uri       string
-}
-
-func TestMaxAge(t *testing.T) {
-	Convey("Given a list of URIs and some pre-configured cache time values", t, func() {
+func TestMaxAgeLongCacheTime(t *testing.T) {
+	Convey("Given a list of URIs and a pre-configured long cache time", t, func() {
 		ctx := context.Background()
-		defaultCacheTime := 100
-		longCacheTime := 9999
+		const longCacheTime = 9999
 		cfg := &config.Config{
-			CacheTimeDefault: time.Duration(defaultCacheTime) * time.Second,
-			CacheTimeLong:    time.Duration(longCacheTime) * time.Second,
+			CacheTimeLong: time.Duration(longCacheTime) * time.Second,
 		}
 
-		versionedURIs := []TestCase{
-			{longCacheTime, "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1"},
-			{longCacheTime, "/chartimage?uri=economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1/30d7d6c2"},
-			{longCacheTime, "/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1/30d7d6c2/data"},
-			{longCacheTime, "/file?uri=/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpilemindicesandpricequotes/pricequotesseptember2023/previous/v1/pricequotes202309.xlsx"},
-			{longCacheTime, "/file?uri=/economy/inflationandpriceindices/datasets/consumerpriceindices/current/previous/v103/mm23.csv"},
+		versionedURIs := []string{
+			"/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1",
+			"/chartimage?uri=economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1/30d7d6c2",
+			"/economy/inflationandpriceindices/bulletins/producerpriceinflation/october2022/previous/v1/30d7d6c2/data",
+			"/file?uri=/economy/inflationandpriceindices/datasets/consumerpriceindicescpiandretailpricesindexrpilemindicesandpricequotes/pricequotesseptember2023/previous/v1/pricequotes202309.xlsx",
+			"/file?uri=/economy/inflationandpriceindices/datasets/consumerpriceindices/current/previous/v103/mm23.csv",
 		}
 
-		onsURIs := []TestCase{
-			{longCacheTime, "/ons/rel/household-income/the-effects-of-taxes-and-benefits-on-household-income/index.html"},
-			{longCacheTime, "/ons/rel/integrated-household-survey/integrated-household-survey/index.html"},
+		onsURIs := []string{
+			"/ons/rel/household-income/the-effects-of-taxes-and-benefits-on-household-income/index.html",
+			"/ons/rel/integrated-household-survey/integrated-household-survey/index.html",
 		}
 
-		legacyAssetURIs := []TestCase{
-			{longCacheTime, "/img/national-statistics.png"},
-			{longCacheTime, "/css/main.css"},
-			{longCacheTime, "/scss/some-sass-file.scss"},
-			{longCacheTime, "/js/app.js"},
-			{longCacheTime, "/fonts/open-sans-regular/OpenSans-Regular-webfont.woff2"},
-			{longCacheTime, "/favicon.ico"},
+		legacyAssetURIs := []string{
+			"/img/national-statistics.png",
+			"/css/main.css",
+			"/scss/some-sass-file.scss",
+			"/js/app.js",
+			"/fonts/open-sans-regular/OpenSans-Regular-webfont.woff2",
+			"/favicon.ico",
 		}
 
-		regularURIs := []TestCase{
-			{defaultCacheTime, "/this-uri/does-not-fall-into-any-special-category"},
-			{defaultCacheTime, "/employmentandlabourmarket"},
-		}
-
-		groupedTestCases := [][]TestCase{
+		groupedTestCases := [][]string{
 			versionedURIs,
 			onsURIs,
 			legacyAssetURIs,
-			regularURIs,
 		}
 
 		Convey("When the 'maxAge' function is called", func() {
 			for _, testCases := range groupedTestCases {
-				for _, tc := range testCases {
-					result := maxAge(ctx, tc.uri, cfg)
+				for _, uri := range testCases {
+					result := maxAge(ctx, uri, cfg)
 
-					Convey(fmt.Sprintf(`Then it should return a cache time of %d seconds for the following URI: %q`, tc.cacheTime, tc.uri), func() {
-						So(result, ShouldEqual, tc.cacheTime)
+					Convey("Then it should return a long cache time for the following URI: "+uri, func() {
+						So(result, ShouldEqual, longCacheTime)
 					})
 				}
 			}
+		})
+	})
+}
+
+func TestMaxAgeInteractionWithLegacyCacheAPI(t *testing.T) {
+	Convey("Given a Legacy Cache API and some pre-configured cache time values", t, func() {
+		ctx := context.Background()
+
+		mux := http.NewServeMux()
+		mockLegacyCacheAPI := httptest.NewServer(mux)
+		defer mockLegacyCacheAPI.Close()
+
+		setMockResponseBody := func(body string) {
+			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(body))
+			})
+		}
+
+		setMockResponseStatusCode := func(statusCode int) {
+			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(statusCode)
+			})
+		}
+
+		setMockResponseWithReleaseTime := func(releaseTime time.Time) {
+			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				body := fmt.Sprintf(`{"_id": "7fadfea5c8372c59c0d20599ff95b42a", "path": "/some-valid-path", "release_time": %q}`, releaseTime.Format(time.RFC3339))
+				_, _ = w.Write([]byte(body))
+			})
+		}
+
+		const defaultCacheTime = 100
+		const erroredCacheTime = 50
+		const shortCacheTime = 3
+
+		const publishExpiryOffset = 15
+
+		cfg := &config.Config{
+			LegacyCacheAPIURL:   mockLegacyCacheAPI.URL,
+			CacheTimeDefault:    time.Duration(defaultCacheTime) * time.Second,
+			CacheTimeErrored:    time.Duration(erroredCacheTime) * time.Second,
+			CacheTimeShort:      time.Duration(shortCacheTime) * time.Second,
+			PublishExpiryOffset: time.Duration(publishExpiryOffset) * time.Second,
+		}
+
+		Convey("When the 'maxAge' function is called and there is a problem trying to retrieve a Cache Time resource", func() {
+			setMockResponseBody("invalid response")
+			result := maxAge(ctx, "/some-valid-url", cfg)
+
+			Convey("Then it should return an errored cache time", func() {
+				So(result, ShouldEqual, erroredCacheTime)
+			})
+		})
+
+		Convey("When the 'maxAge' function is called and there is a problem with the API", func() {
+			setMockResponseStatusCode(http.StatusInternalServerError)
+			result := maxAge(ctx, "/some-valid-url", cfg)
+
+			Convey("Then it should return an errored cache time", func() {
+				So(result, ShouldEqual, erroredCacheTime)
+			})
+		})
+
+		Convey("When the 'maxAge' function is called and the API does not have the requested Cache Time resource", func() {
+			setMockResponseStatusCode(http.StatusNotFound)
+			result := maxAge(ctx, "/some-valid-url", cfg)
+
+			Convey("Then it should return a default cache time", func() {
+				So(result, ShouldEqual, defaultCacheTime)
+			})
+		})
+
+		Convey("When the 'maxAge' function is called and the requested Cache Time resource does not have a release time", func() {
+			setMockResponseBody(`{"_id": "7fadfea5c8372c59c0d20599ff95b42a", "path": "/some-valid-path"}`)
+			result := maxAge(ctx, "/some-valid-url", cfg)
+
+			Convey("Then it should return a default cache time", func() {
+				So(result, ShouldEqual, defaultCacheTime)
+			})
+		})
+
+		Convey("When the 'maxAge' function is called and the requested Cache Time resource has a release time", func() {
+			Convey("And the release time is in the future", func() {
+				Convey("And the release will happen very soon", func() {
+					futureReleaseTime := time.Now().Add(30 * time.Second)
+					secondsUntilRelease := time.Until(futureReleaseTime).Seconds()
+					So(secondsUntilRelease, ShouldBeLessThan, defaultCacheTime)
+					setMockResponseWithReleaseTime(futureReleaseTime)
+					result := maxAge(ctx, "/some-valid-url", cfg)
+
+					Convey("Then it should return a calculated cache time", func() {
+						// Small error threshold (in seconds) to account for result discrepancies due to using an actual
+						// time (not mocked) and the tests possibly running slow
+						errorThreshold := 3
+						So(result, ShouldAlmostEqual, secondsUntilRelease, errorThreshold)
+					})
+				})
+
+				Convey("And the release will not happen soon", func() {
+					futureReleaseTime := time.Now().Add(999999 * time.Hour)
+					secondsUntilRelease := time.Until(futureReleaseTime).Seconds()
+					So(secondsUntilRelease, ShouldBeGreaterThan, defaultCacheTime)
+					setMockResponseWithReleaseTime(futureReleaseTime)
+					result := maxAge(ctx, "/some-valid-url", cfg)
+
+					Convey("Then it should return a default cache time", func() {
+						So(result, ShouldEqual, defaultCacheTime)
+					})
+				})
+			})
+
+			Convey("And the release time is in the past", func() {
+				Convey("And it was released recently", func() {
+					pastReleaseTime := time.Now().Add(-3 * time.Second)
+					secondsSinceRelease := time.Since(pastReleaseTime).Seconds()
+					So(secondsSinceRelease, ShouldBeLessThan, publishExpiryOffset)
+					setMockResponseWithReleaseTime(pastReleaseTime)
+					result := maxAge(ctx, "/some-valid-url", cfg)
+
+					Convey("Then it should return a short cache time", func() {
+						So(result, ShouldEqual, shortCacheTime)
+					})
+				})
+
+				Convey("And it was not released recently", func() {
+					pastReleaseTime := time.Now().Add(-99999999 * time.Second)
+					secondsSinceRelease := time.Since(pastReleaseTime).Seconds()
+					So(secondsSinceRelease, ShouldBeGreaterThan, publishExpiryOffset)
+					setMockResponseWithReleaseTime(pastReleaseTime)
+					result := maxAge(ctx, "/some-valid-url", cfg)
+
+					Convey("Then it should return a default cache time", func() {
+						So(result, ShouldEqual, defaultCacheTime)
+					})
+				})
+			})
 		})
 	})
 }

--- a/response/page_path.go
+++ b/response/page_path.go
@@ -1,0 +1,14 @@
+package response
+
+import (
+	"context"
+
+	"github.com/ONSdigital/log.go/v2/log"
+)
+
+func getPagePath(ctx context.Context, uri string) string {
+	log.Info(ctx, "Calculating page path for "+uri)
+
+	// TODO To be implemented as part of DIS-413
+	return uri
+}

--- a/response/release_time.go
+++ b/response/release_time.go
@@ -1,0 +1,67 @@
+package response
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+type CacheTime struct {
+	ReleaseTime *time.Time `json:"release_time"`
+}
+
+func getReleaseTime(path, legacyCacheAPIURL string) (time.Time, int, error) {
+	pathHash := md5.Sum([]byte(path))
+	cacheTimeID := hex.EncodeToString(pathHash[:])
+	cacheTimeResourceURL := legacyCacheAPIURL + "/v1/cache-times/" + cacheTimeID
+
+	cacheTimeResource, statusCode, err := fetchCacheTimeResource(cacheTimeResourceURL)
+	if err != nil {
+		return time.Time{}, 0, err
+	}
+
+	var releaseTime time.Time
+	if cacheTimeResource.ReleaseTime != nil {
+		releaseTime = *cacheTimeResource.ReleaseTime
+	} else {
+		releaseTime = time.Time{}
+	}
+
+	return releaseTime, statusCode, nil
+}
+
+func fetchCacheTimeResource(cacheTimeResourceURL string) (CacheTime, int, error) {
+	req, err := http.NewRequest(http.MethodGet, cacheTimeResourceURL, http.NoBody)
+	if err != nil {
+		return CacheTime{}, 0, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return CacheTime{}, 0, err
+	}
+
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return CacheTime{}, resp.StatusCode, nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return CacheTime{}, 0, err
+	}
+
+	var cacheTimeResource CacheTime
+	err = json.Unmarshal(body, &cacheTimeResource)
+	if err != nil {
+		return CacheTime{}, 0, err
+	}
+
+	return cacheTimeResource, resp.StatusCode, nil
+}

--- a/response/release_time_test.go
+++ b/response/release_time_test.go
@@ -1,0 +1,103 @@
+package response
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetReleaseTime(t *testing.T) {
+	Convey("Given a Legacy Cache API", t, func() {
+		var writeMockResponse func(w http.ResponseWriter) error
+		mockLegacyCacheAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err := writeMockResponse(w)
+			if err != nil {
+				t.Fatal("error setting the mock server response body", err)
+			}
+		}))
+		defer mockLegacyCacheAPI.Close()
+
+		Convey("When 'getReleaseTime' is called and a Cache Time resource with a Release Time is returned from the API", func() {
+			cacheTimeResource := `
+			{
+				"_id": "7fadfea5c8372c59c0d20599ff95b42a",
+				"path": "/some-valid-path",
+				"collection_id": 123456,
+				"release_time": "2024-01-31T01:23:45.678Z"
+			}`
+			writeMockResponse = setMockResponse(cacheTimeResource, http.StatusOK)
+
+			releaseTime, statusCode, err := getReleaseTime("/some-valid-path", mockLegacyCacheAPI.URL)
+
+			Convey("Then the result is the Release Time and status code with no errors", func() {
+				expectedReleaseTime, _ := time.Parse(time.RFC3339, "2024-01-31T01:23:45.678Z")
+				So(releaseTime, ShouldEqual, expectedReleaseTime)
+				So(statusCode, ShouldEqual, http.StatusOK)
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("When 'getReleaseTime' is called and a Cache Time resource with no Release Time is returned from the API", func() {
+			cacheTimeResource := `
+			{
+				"_id": "7fadfea5c8372c59c0d20599ff95b42a",
+				"path": "/some-valid-path"
+			}`
+			writeMockResponse = setMockResponse(cacheTimeResource, http.StatusOK)
+
+			releaseTime, statusCode, err := getReleaseTime("/some-valid-path", mockLegacyCacheAPI.URL)
+
+			Convey("Then the result is an empty Release Time and status code with no errors", func() {
+				So(releaseTime.IsZero(), ShouldBeTrue)
+				So(statusCode, ShouldEqual, http.StatusOK)
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("When 'getReleaseTime' is called and a Cache Time resource is not found in the API", func() {
+			writeMockResponse = setMockResponse("", http.StatusNotFound)
+
+			releaseTime, statusCode, err := getReleaseTime("/some-valid-path", mockLegacyCacheAPI.URL)
+
+			Convey("Then the result is an empty Release Time and a Not Found status code with no errors", func() {
+				So(releaseTime.IsZero(), ShouldBeTrue)
+				So(statusCode, ShouldEqual, http.StatusNotFound)
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("When 'getReleaseTime' is called and an unexpected status code is returned from the API", func() {
+			writeMockResponse = setMockResponse("", http.StatusBadGateway)
+
+			releaseTime, statusCode, err := getReleaseTime("/some-valid-path", mockLegacyCacheAPI.URL)
+
+			Convey("Then the result is an empty Release Time and the same status code with no errors", func() {
+				So(releaseTime.IsZero(), ShouldBeTrue)
+				So(statusCode, ShouldEqual, http.StatusBadGateway)
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("When 'getReleaseTime' is called and there is an error with the API", func() {
+			writeMockResponse = nil
+
+			_, _, err := getReleaseTime("/some-valid-path", "invalid-API-URL")
+
+			Convey("Then an error should be returned", func() {
+				So(err, ShouldNotBeNil)
+			})
+		})
+	})
+}
+
+func setMockResponse(body string, statusCode int) func(http.ResponseWriter) error {
+	return func(w http.ResponseWriter) error {
+		w.WriteHeader(statusCode)
+		_, err := fmt.Fprint(w, body)
+		return err
+	}
+}

--- a/response/writer.go
+++ b/response/writer.go
@@ -43,6 +43,7 @@ func writeResponse(ctx context.Context, w http.ResponseWriter, babbageResponse *
 	if _, err := io.Copy(w, babbageResponse.Body); err != nil {
 		log.Error(ctx, "error copying the proxy response's body", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
 	}
 }
 


### PR DESCRIPTION
### What

Implemented the scenarios in which the `max-age` directive is set based on the information stored in the API.

Please note that in order to query the Legacy Cache API, we also need to calculate the page path that we send to the API. This will be done as part of DIS-413, as you can read in the comment inside the `getPagePath` function (which has been added as part of this PR to allow others to work simultaneously on that ticket).

### How to review

Examine the diagram linked in DIS-412 and ensure that this PR implements it.

### Who can review

Anyone at ONS.
