### PR TITLE
Redirect to release calendar URLs to dp-frontend-release-calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Proxy for handling the cache for pages within the legacy CMS
 | BABBAGE_URL                  | http://localhost:8080  | Babbage address, where all the incoming requests are forwarded to                                                                    |
 | LEGACY_CACHE_API_URL         | http://localhost:29100 | Legacy Cache API address                                                                                                             |
 | RELEASE_CALENDAR_URL         | http://localhost:27700 | Release calendar frontend controller address                                                                                         |
+| ENABLE_RELEASE_CALENDAR      | false                  | Flag to enable `/releases/{uri:.*}` URLs to go through dp-frontend-release-calendar instead.                                         |
 | CACHE_TIME_DEFAULT           | 15m                    | Default value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                                     |
 | CACHE_TIME_ERRORED           | 30s                    | Errored value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                                     |
 | CACHE_TIME_LONG              | 4h                     | Long value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                                        |

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Proxy for handling the cache for pages within the legacy CMS
 | OTEL_SERVICE_NAME            | dp-legacy-cache-proxy  | The name of this service in OpenTelemetry                                                                                            |
 | BABBAGE_URL                  | http://localhost:8080  | Babbage address, where all the incoming requests are forwarded to                                                                    |
 | LEGACY_CACHE_API_URL         | http://localhost:29100 | Legacy Cache API address                                                                                                             |
+| RELEASE_CALENDAR_URL         | http://localhost:27700 | Release calendar frontend controller address                                                                                         |
 | CACHE_TIME_DEFAULT           | 15m                    | Default value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                                     |
 | CACHE_TIME_ERRORED           | 30s                    | Errored value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                                     |
 | CACHE_TIME_LONG              | 4h                     | Long value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                                        |

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	OTExporterOTLPEndpoint     string        `envconfig:"OTEL_EXPORTER_OTLP_ENDPOINT"`
 	OTServiceName              string        `envconfig:"OTEL_SERVICE_NAME"`
 	BabbageURL                 string        `envconfig:"BABBAGE_URL"`
+	RelCalURL                  string        `envconfig:"RELEASE_CALENDAR_URL"`
 	LegacyCacheAPIURL          string        `envconfig:"LEGACY_CACHE_API_URL"`
 	CacheTimeDefault           time.Duration `envconfig:"CACHE_TIME_DEFAULT"`
 	CacheTimeErrored           time.Duration `envconfig:"CACHE_TIME_ERRORED"`
@@ -44,6 +45,7 @@ func Get() (*Config, error) {
 		OTServiceName:              "dp-legacy-cache-proxy",
 		BabbageURL:                 "http://localhost:8080",
 		LegacyCacheAPIURL:          "http://localhost:29100",
+		RelCalURL:                  "http://localhost:27700",
 		CacheTimeDefault:           15 * time.Minute,
 		CacheTimeErrored:           30 * time.Second,
 		CacheTimeLong:              4 * time.Hour,

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	OTServiceName              string        `envconfig:"OTEL_SERVICE_NAME"`
 	BabbageURL                 string        `envconfig:"BABBAGE_URL"`
 	RelCalURL                  string        `envconfig:"RELEASE_CALENDAR_URL"`
+	EnableReleaseCalendar      bool          `envconfig:"ENABLE_RELEASE_CALENDAR"`
 	LegacyCacheAPIURL          string        `envconfig:"LEGACY_CACHE_API_URL"`
 	CacheTimeDefault           time.Duration `envconfig:"CACHE_TIME_DEFAULT"`
 	CacheTimeErrored           time.Duration `envconfig:"CACHE_TIME_ERRORED"`
@@ -46,6 +47,7 @@ func Get() (*Config, error) {
 		BabbageURL:                 "http://localhost:8080",
 		LegacyCacheAPIURL:          "http://localhost:29100",
 		RelCalURL:                  "http://localhost:27700",
+		EnableReleaseCalendar:      false,
 		CacheTimeDefault:           15 * time.Minute,
 		CacheTimeErrored:           30 * time.Second,
 		CacheTimeLong:              4 * time.Hour,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,6 +32,7 @@ func TestConfig(t *testing.T) {
 					OTServiceName:              "dp-legacy-cache-proxy",
 					BabbageURL:                 "http://localhost:8080",
 					LegacyCacheAPIURL:          "http://localhost:29100",
+					RelCalURL:                  "http://localhost:27700",
 					CacheTimeDefault:           15 * time.Minute,
 					CacheTimeErrored:           30 * time.Second,
 					CacheTimeLong:              4 * time.Hour,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,6 +33,7 @@ func TestConfig(t *testing.T) {
 					BabbageURL:                 "http://localhost:8080",
 					LegacyCacheAPIURL:          "http://localhost:29100",
 					RelCalURL:                  "http://localhost:27700",
+					EnableReleaseCalendar:      false,
 					CacheTimeDefault:           15 * time.Minute,
 					CacheTimeErrored:           30 * time.Second,
 					CacheTimeLong:              4 * time.Hour,

--- a/dp-legacy-cache-proxy.nomad
+++ b/dp-legacy-cache-proxy.nomad
@@ -66,6 +66,7 @@ job "dp-legacy-cache-proxy" {
 
         export BABBAGE_URL="http://{{ env "NOMAD_IP_http" }}:10000"
         export LEGACY_CACHE_API_URL="http://{{ env "NOMAD_IP_http" }}:13850"
+        export RELEASE_CALENDAR_URL="http://{{ env "NOMAD_IP_http" }}:13000"
 
         # Secret configs read from vault
         {{ with (secret (print "secret/" (env "NOMAD_TASK_NAME"))) }}

--- a/features/release_calendar_response.feature
+++ b/features/release_calendar_response.feature
@@ -1,0 +1,17 @@
+Feature: Proxy returns response from Release Calendar
+
+    The proxy can be called with Release Calendar URLs (for instance, "/releases/adoption"),
+    when this happens we want to ensure that the proxy forwards the URL to the Release Calendar. 
+
+  Scenario: Proxy returns response from Release Calendar
+    Given Release calendar will send the following response with status "200":
+      """
+      Mock response from Release Calendar
+      """
+    When the Proxy receives a GET request for "/releases/some-path"
+    Then the response header "Cache-Control" should be "max-age=900"
+    And the HTTP status code should be "200"
+    And I should receive the following response:
+      """
+      Mock response from Release Calendar
+      """

--- a/features/steps/proxy_component.go
+++ b/features/steps/proxy_component.go
@@ -16,15 +16,16 @@ import (
 
 type Component struct {
 	componenttest.ErrorFeature
-	svcList               *service.ExternalServiceList
-	svc                   *service.Service
-	errorChan             chan error
-	Config                *config.Config
-	HTTPServer            *http.Server
-	ServiceRunning        bool
-	apiFeature            *componenttest.APIFeature
-	babbageFeature        *BabbageFeature
-	legacyCacheAPIFeature *LegacyCacheAPIFeature
+	svcList                *service.ExternalServiceList
+	svc                    *service.Service
+	errorChan              chan error
+	Config                 *config.Config
+	HTTPServer             *http.Server
+	ServiceRunning         bool
+	apiFeature             *componenttest.APIFeature
+	babbageFeature         *BabbageFeature
+	legacyCacheAPIFeature  *LegacyCacheAPIFeature
+	releaseCalendarFeature *ReleaseCalendarFeature
 }
 
 func NewComponent() (*Component, error) {
@@ -42,9 +43,11 @@ func NewComponent() (*Component, error) {
 
 	c.babbageFeature = NewBabbageFeature()
 	c.legacyCacheAPIFeature = NewLegacyCacheAPIFeature()
+	c.releaseCalendarFeature = NewReleaseCalendarFeature()
 
 	c.Config.BabbageURL = c.babbageFeature.Server.URL
 	c.Config.LegacyCacheAPIURL = c.legacyCacheAPIFeature.Server.URL
+	c.Config.RelCalURL = c.releaseCalendarFeature.Server.URL
 	c.Config.EnablePublishExpiryOffset = true
 
 	initMock := &mock.InitialiserMock{
@@ -70,6 +73,7 @@ func (c *Component) Close() error {
 	if c.svc != nil && c.ServiceRunning {
 		c.babbageFeature.Server.Close()
 		c.legacyCacheAPIFeature.Server.Close()
+		c.releaseCalendarFeature.Server.Close()
 		if err := c.svc.Close(context.Background()); err != nil {
 			return err
 		}

--- a/features/steps/proxy_component.go
+++ b/features/steps/proxy_component.go
@@ -48,6 +48,7 @@ func NewComponent() (*Component, error) {
 	c.Config.BabbageURL = c.babbageFeature.Server.URL
 	c.Config.LegacyCacheAPIURL = c.legacyCacheAPIFeature.Server.URL
 	c.Config.RelCalURL = c.releaseCalendarFeature.Server.URL
+	c.Config.EnableReleaseCalendar = true
 	c.Config.EnablePublishExpiryOffset = true
 
 	initMock := &mock.InitialiserMock{

--- a/features/steps/release_calendar_feature.go
+++ b/features/steps/release_calendar_feature.go
@@ -1,0 +1,58 @@
+package steps
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+
+	"github.com/cucumber/godog"
+)
+
+type ReleaseCalendarFeature struct {
+	Server     *httptest.Server
+	Body       string
+	StatusCode int
+	Headers    map[string]string
+}
+
+func NewReleaseCalendarFeature() *ReleaseCalendarFeature {
+	f := ReleaseCalendarFeature{
+		Headers: make(map[string]string),
+	}
+
+	f.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for headerName, headerValue := range f.Headers {
+			w.Header().Set(headerName, headerValue)
+		}
+
+		w.WriteHeader(f.StatusCode)
+
+		if _, err := w.Write([]byte(f.Body)); err != nil {
+			panic(err)
+		}
+	}))
+
+	return &f
+}
+
+func (f *ReleaseCalendarFeature) RegisterSteps(ctx *godog.ScenarioContext) {
+	ctx.Step(`^Release calendar will send the following response with status "([^"]*)":$`, f.releaseCalendarWillSendTheFollowingResponseWithStatus)
+}
+
+func (f *ReleaseCalendarFeature) releaseCalendarWillSendTheFollowingResponseWithStatus(statusCodeStr string, releaseCalendarBody *godog.DocString) error {
+	f.Body = strings.TrimSpace(releaseCalendarBody.Content)
+
+	return f.releaseCalendarWillSetTheHTTPStatusCodeTo(statusCodeStr)
+}
+
+func (f *ReleaseCalendarFeature) releaseCalendarWillSetTheHTTPStatusCodeTo(statusCodeStr string) error {
+	statusCode, err := strconv.Atoi(statusCodeStr)
+	if err != nil {
+		return err
+	}
+
+	f.StatusCode = statusCode
+
+	return nil
+}

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -14,6 +14,7 @@ func (c *Component) RegisterSteps(ctx *godog.ScenarioContext) {
 	c.apiFeature.RegisterSteps(ctx)
 	c.babbageFeature.RegisterSteps(ctx)
 	c.legacyCacheAPIFeature.RegisterSteps(ctx)
+	c.releaseCalendarFeature.RegisterSteps(ctx)
 
 	ctx.Step(`^I should receive an empty response$`, c.iShouldReceiveAnEmptyResponse)
 	ctx.Step(`^I should receive the same, unmodified response from Babbage$`, c.iShouldReceiveTheSameUnmodifiedResponseFromBabbage)

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240116215550-a9fa1716bcac // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240116215550-a9fa1716bcac // indirect
 	google.golang.org/grpc v1.60.1 // indirect
-	google.golang.org/protobuf v1.32.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -240,6 +240,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
 google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/proxy/manager.go
+++ b/proxy/manager.go
@@ -47,7 +47,7 @@ func IsReleaseCalendarURL(url string) bool {
 }
 
 func getTargetURL(requestURL string, cfg *config.Config) string {
-	if IsReleaseCalendarURL(requestURL) {
+	if IsReleaseCalendarURL(requestURL) && cfg.EnableReleaseCalendar {
 		return cfg.RelCalURL + requestURL
 	}
 	return cfg.BabbageURL + requestURL

--- a/proxy/manager.go
+++ b/proxy/manager.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
 	"github.com/ONSdigital/dp-legacy-cache-proxy/response"
@@ -10,7 +11,7 @@ import (
 )
 
 func (proxy *Proxy) manage(ctx context.Context, w http.ResponseWriter, req *http.Request, cfg *config.Config) {
-	targetURL := cfg.BabbageURL + req.URL.String()
+	targetURL := getTargetURL(req.URL.String(), cfg)
 
 	proxyReq, err := http.NewRequestWithContext(ctx, req.Method, targetURL, req.Body)
 
@@ -24,7 +25,7 @@ func (proxy *Proxy) manage(ctx context.Context, w http.ResponseWriter, req *http
 	proxyReq.Header = req.Header
 
 	client := &http.Client{}
-	babbageResponse, err := client.Do(proxyReq)
+	serviceResponse, err := client.Do(proxyReq)
 
 	if err != nil {
 		log.Error(ctx, "error sending the proxy request", err)
@@ -33,10 +34,21 @@ func (proxy *Proxy) manage(ctx context.Context, w http.ResponseWriter, req *http
 	}
 
 	defer func() {
-		if closeErr := babbageResponse.Body.Close(); closeErr != nil {
+		if closeErr := serviceResponse.Body.Close(); closeErr != nil {
 			log.Error(ctx, "error closing the response body", closeErr)
 		}
 	}()
 
-	response.WriteResponse(ctx, w, babbageResponse, req, cfg)
+	response.WriteResponse(ctx, w, serviceResponse, req, cfg)
+}
+
+func IsReleaseCalendarURL(url string) bool {
+	return strings.HasPrefix(url, "/releases/")
+}
+
+func getTargetURL(requestURL string, cfg *config.Config) string {
+	if IsReleaseCalendarURL(requestURL) {
+		return cfg.RelCalURL + requestURL
+	}
+	return cfg.BabbageURL + requestURL
 }

--- a/proxy/manager_test.go
+++ b/proxy/manager_test.go
@@ -1,4 +1,4 @@
-package proxy_test
+package proxy
 
 import (
 	"context"
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
-	"github.com/ONSdigital/dp-legacy-cache-proxy/proxy"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -28,7 +27,7 @@ func TestProxyHandleRequestOK(t *testing.T) {
 		router := mux.NewRouter()
 		cfg := &config.Config{BabbageURL: mockBabbageServer.URL}
 
-		legacyCacheProxy := proxy.Setup(ctx, router, cfg)
+		legacyCacheProxy := Setup(ctx, router, cfg)
 
 		Convey("When a request is sent", func() {
 			w := httptest.NewRecorder()
@@ -49,7 +48,7 @@ func TestProxyHandleRequestError(t *testing.T) {
 		ctx := context.Background()
 		router := mux.NewRouter()
 		cfg := &config.Config{BabbageURL: "invalid-babbage-url"}
-		legacyCacheProxy := proxy.Setup(ctx, router, cfg)
+		legacyCacheProxy := Setup(ctx, router, cfg)
 
 		Convey("When a request is sent", func() {
 			w := httptest.NewRecorder()
@@ -59,6 +58,47 @@ func TestProxyHandleRequestError(t *testing.T) {
 			Convey("Then the proxy should return a 500 Internal Server Error", func() {
 				So(w.Code, ShouldEqual, http.StatusInternalServerError)
 			})
+		})
+	})
+}
+
+func TestIsReleaseCalendarURL(t *testing.T) {
+	Convey("Given a list of release calendar URLs", t, func() {
+		releaseCalendarURLs := []string{
+			"/releases/greenjobscurrentandupcomingworkmarch2022",
+			"/releases/post2019westminsterparliamentaryconstituenciesandseneddelectoralregionsdataenglandandwalescensus2021",
+			"/releases/mycollectionpage1",
+			"/releases/timespentinnature",
+			"/releases/constructionstatisticsgreatbritain2022",
+		}
+
+		Convey("When the 'IsReleaseCalendarURL' function is called", func() {
+			for _, url := range releaseCalendarURLs {
+				isReleaseCalendar := IsReleaseCalendarURL(url)
+
+				Convey("Then it should evaluate to true for "+url, func() {
+					So(isReleaseCalendar, ShouldBeTrue)
+				})
+			}
+		})
+	})
+	Convey("Given a list of babbage URLs", t, func() {
+		babbageURLs := []string{
+			"/visualisations/dvc1945/seasonalflu/index.html",
+			"/generator?uri=/economy/economicoutputandproductivity/output/bulletins/economicactivityandsocialchangeintheukrealtimeindicators/15february2024/426e63a0&format=csv",
+			"/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest",
+			"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/linechartconfig",
+			"/businessindustryandtrade/changestobusiness/mergersandacquisitions/datasets/timeseries/15march2024",
+		}
+
+		Convey("When the 'IsReleaseCalendarURL' function is called", func() {
+			for _, url := range babbageURLs {
+				isReleaseCalendar := IsReleaseCalendarURL(url)
+
+				Convey("Then it should evaluate to false for "+url, func() {
+					So(isReleaseCalendar, ShouldBeFalse)
+				})
+			}
 		})
 	})
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1,4 +1,4 @@
-package proxy_test
+package proxy
 
 import (
 	"context"
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
-	"github.com/ONSdigital/dp-legacy-cache-proxy/proxy"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -17,7 +16,7 @@ func TestSetup(t *testing.T) {
 		r := mux.NewRouter()
 		ctx := context.Background()
 		cfg := &config.Config{}
-		legacyCacheProxy := proxy.Setup(ctx, r, cfg)
+		legacyCacheProxy := Setup(ctx, r, cfg)
 
 		Convey("When created, all HTTP methods should be accepted", func() {
 			So(hasRoute(legacyCacheProxy.Router, "/", http.MethodGet), ShouldBeTrue)

--- a/response/writer.go
+++ b/response/writer.go
@@ -10,22 +10,22 @@ import (
 	"github.com/ONSdigital/log.go/v2/log"
 )
 
-func WriteResponse(ctx context.Context, w http.ResponseWriter, babbageResponse *http.Response, req *http.Request, cfg *config.Config) {
+func WriteResponse(ctx context.Context, w http.ResponseWriter, serviceResponse *http.Response, req *http.Request, cfg *config.Config) {
 	if !isGetOrHead(req.Method) {
-		writeUnmodifiedResponse(ctx, w, babbageResponse)
-	} else if !isCacheableStatusCode(babbageResponse.StatusCode) {
-		writeUnmodifiedResponse(ctx, w, babbageResponse)
-	} else if cacheControl := babbageResponse.Header.Get("Cache-Control"); !shouldCalculateMaxAge(cacheControl) {
-		writeUnmodifiedResponse(ctx, w, babbageResponse)
+		writeUnmodifiedResponse(ctx, w, serviceResponse)
+	} else if !isCacheableStatusCode(serviceResponse.StatusCode) {
+		writeUnmodifiedResponse(ctx, w, serviceResponse)
+	} else if cacheControl := serviceResponse.Header.Get("Cache-Control"); !shouldCalculateMaxAge(cacheControl) {
+		writeUnmodifiedResponse(ctx, w, serviceResponse)
 	} else {
 		maxAgeInSeconds := maxAge(ctx, req.RequestURI, cfg)
-		writeResponseWithMaxAge(ctx, w, babbageResponse, maxAgeInSeconds)
+		writeResponseWithMaxAge(ctx, w, serviceResponse, maxAgeInSeconds)
 	}
 }
 
-func writeResponse(ctx context.Context, w http.ResponseWriter, babbageResponse *http.Response, overrideHeaders map[string]string) {
-	// Copy the Babbage response's headers
-	for name, values := range babbageResponse.Header {
+func writeResponse(ctx context.Context, w http.ResponseWriter, serviceResponse *http.Response, overrideHeaders map[string]string) {
+	// Copy the service response's headers
+	for name, values := range serviceResponse.Header {
 		for _, value := range values {
 			w.Header().Add(name, value)
 		}
@@ -36,34 +36,34 @@ func writeResponse(ctx context.Context, w http.ResponseWriter, babbageResponse *
 		w.Header().Set(name, value)
 	}
 
-	// Copy the Babbage response's status code
-	w.WriteHeader(babbageResponse.StatusCode)
+	// Copy the service response's status code
+	w.WriteHeader(serviceResponse.StatusCode)
 
-	// Copy the Babbage response's body
-	if _, err := io.Copy(w, babbageResponse.Body); err != nil {
+	// Copy the service response's body
+	if _, err := io.Copy(w, serviceResponse.Body); err != nil {
 		log.Error(ctx, "error copying the proxy response's body", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 }
 
-func writeUnmodifiedResponse(ctx context.Context, w http.ResponseWriter, babbageResponse *http.Response) {
+func writeUnmodifiedResponse(ctx context.Context, w http.ResponseWriter, serviceResponse *http.Response) {
 	noAdditionalHeaders := map[string]string{}
-	writeResponse(ctx, w, babbageResponse, noAdditionalHeaders)
+	writeResponse(ctx, w, serviceResponse, noAdditionalHeaders)
 }
 
-func writeResponseWithMaxAge(ctx context.Context, w http.ResponseWriter, babbageResponse *http.Response, maxAge int) {
+func writeResponseWithMaxAge(ctx context.Context, w http.ResponseWriter, serviceResponse *http.Response, maxAge int) {
 	overrideHeaders := make(map[string]string)
 
 	// Get the original Cache-Control value and modify it to include max-age
-	originalCacheControl := babbageResponse.Header.Get("Cache-Control")
+	originalCacheControl := serviceResponse.Header.Get("Cache-Control")
 	if originalCacheControl != "" {
 		overrideHeaders["Cache-Control"] = fmt.Sprintf("%s, max-age=%d", originalCacheControl, maxAge)
 	} else {
 		overrideHeaders["Cache-Control"] = fmt.Sprintf("max-age=%d", maxAge)
 	}
 
-	writeResponse(ctx, w, babbageResponse, overrideHeaders)
+	writeResponse(ctx, w, serviceResponse, overrideHeaders)
 }
 
 func isGetOrHead(method string) bool {


### PR DESCRIPTION
### What

Any release calendar URLs that are received by dp-legacy-cache-proxy are forwarded to dp-frontend-release-calendar

### How to review

1. Run tests with 'make test'
2. In the dp-frontend-router checkout the branch of https://github.com/ONSdigital/dp-frontend-router/pull/451 
3. Set LEGACY_CACHE_PROXY_ENABLED to true by running this on the terminal
4. export LEGACY_CACHE_PROXY_ENABLED=true and run dp-frontend-router make debug
5. Run dp-legacy-cache-proxy make debug
6. Run dp-frontend-release-calendar

Make a request to a release calendar endpoint
e.g. http://localhost:20000/releases/adoption

### Who can review

Anyone from ONS
