### PR TITLE
Set buffer size io.copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ All the requests that users make to Babbage (or any other services that rely on 
 | CACHE_TIME_SHORT             | 10s                    | Short value for the `max-age` directive of the `Cache-Control` header (`time.Duration` format)                                       |
 | ENABLE_PUBLISH_EXPIRY_OFFSET | false                  | Determines if publish expiry offset is used which enables a shorter cache time for recently published content.                       |
 | PUBLISH_EXPIRY_OFFSET        | 3m                     | Period of time after a release in which the proxy needs to return a short value for the `max-age` directive (`time.Duration` format) |
+| READ_TIMEOUT                 | 15s                    | Maximum time the server will wait for a client to send a complete request.                                                           |
+| WRITE_TIMEOUT                | 30s                    | Maximum time the server will wait while trying to write a response to the client                                                     |
 
 ### Auto-Deployment of secrets
-Functionality has been added to the nomad plan so that when the secrets are deployed to Vault, this will automatically cause Nomad to trigger a redeployment of the application to pick up the new secrets. Please note that this functionality does not appear to work with the current nomad/vault versions, but if these are upgraded it may then become functional.  
+
+Functionality has been added to the nomad plan so that when the secrets are deployed to Vault, this will automatically cause Nomad to trigger a redeployment of the application to pick up the new secrets. Please note that this functionality does not appear to work with the current nomad/vault versions, but if these are upgraded it may then become functional.
 
 ### Contributing
 

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	CacheTimeShort             time.Duration `envconfig:"CACHE_TIME_SHORT"`
 	EnablePublishExpiryOffset  bool          `envconfig:"ENABLE_PUBLISH_EXPIRY_OFFSET"`
 	PublishExpiryOffset        time.Duration `envconfig:"PUBLISH_EXPIRY_OFFSET"`
+	ReadTimeout                time.Duration `envconfig:"READ_TIMEOUT"`
+	WriteTimeout               time.Duration `envconfig:"WRITE_TIMEOUT"`
 }
 
 var cfg *Config
@@ -54,6 +56,8 @@ func Get() (*Config, error) {
 		CacheTimeShort:             10 * time.Second,
 		EnablePublishExpiryOffset:  false,
 		PublishExpiryOffset:        3 * time.Minute,
+		ReadTimeout:                15 * time.Second,
+		WriteTimeout:               30 * time.Second,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,6 +40,8 @@ func TestConfig(t *testing.T) {
 					CacheTimeShort:             10 * time.Second,
 					EnablePublishExpiryOffset:  false,
 					PublishExpiryOffset:        3 * time.Minute,
+					ReadTimeout:                15 * time.Second,
+					WriteTimeout:               30 * time.Second,
 				})
 			})
 

--- a/features/steps/proxy_component.go
+++ b/features/steps/proxy_component.go
@@ -102,7 +102,7 @@ func (c *Component) DoGetHealthcheckOk(_ *config.Config, _, _, _ string) (servic
 	}, nil
 }
 
-func (c *Component) DoGetHTTPServer(bindAddr string, router http.Handler) service.HTTPServer {
+func (c *Component) DoGetHTTPServer(_ *config.Config, bindAddr string, router http.Handler) service.HTTPServer {
 	c.HTTPServer = &http.Server{
 		ReadHeaderTimeout: 3 * time.Second,
 		Addr:              bindAddr,

--- a/proxy/manager_test.go
+++ b/proxy/manager_test.go
@@ -22,7 +22,6 @@ func TestProxyHandleRequestOK(t *testing.T) {
 			}
 		}))
 		defer mockBabbageServer.Close()
-
 		ctx := context.Background()
 		router := mux.NewRouter()
 		cfg := &config.Config{BabbageURL: mockBabbageServer.URL}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -14,13 +14,13 @@ type Proxy struct {
 }
 
 // Setup function sets up the proxy and returns a Proxy
-func Setup(ctx context.Context, r *mux.Router, cfg *config.Config) *Proxy {
+func Setup(_ context.Context, r *mux.Router, cfg *config.Config) *Proxy {
 	proxy := &Proxy{
 		Router: r,
 	}
 
 	r.PathPrefix("/").Name("Proxy Catch-All").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		proxy.manage(ctx, w, req, cfg)
+		proxy.manage(req.Context(), w, req, cfg)
 	})
 	return proxy
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestSetup(t *testing.T) {
 	Convey("Given a Proxy instance", t, func() {
-		r := mux.NewRouter()
 		ctx := context.Background()
+		r := mux.NewRouter()
 		cfg := &config.Config{}
 		legacyCacheProxy := Setup(ctx, r, cfg)
 

--- a/response/writer.go
+++ b/response/writer.go
@@ -39,8 +39,10 @@ func writeResponse(ctx context.Context, w http.ResponseWriter, serviceResponse *
 	// Copy the service response's status code
 	w.WriteHeader(serviceResponse.StatusCode)
 
+	buf := make([]byte, 128*1024)
+
 	// Copy the service response's body
-	if _, err := io.Copy(w, serviceResponse.Body); err != nil {
+	if _, err := io.CopyBuffer(w, serviceResponse.Body, buf); err != nil {
 		log.Error(ctx, "error copying the proxy response's body", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -3,9 +3,8 @@ package service
 import (
 	"net/http"
 
-	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
-
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
 )
 
@@ -27,8 +26,8 @@ func NewServiceList(initialiser Initialiser) *ExternalServiceList {
 type Init struct{}
 
 // GetHTTPServer creates an http server
-func (e *ExternalServiceList) GetHTTPServer(bindAddr string, router http.Handler) HTTPServer {
-	s := e.Init.DoGetHTTPServer(bindAddr, router)
+func (e *ExternalServiceList) GetHTTPServer(cfg *config.Config, bindAddr string, router http.Handler) HTTPServer {
+	s := e.Init.DoGetHTTPServer(cfg, bindAddr, router)
 	return s
 }
 
@@ -47,8 +46,10 @@ func (e *ExternalServiceList) GetRequestMiddleware() RequestMiddleware {
 }
 
 // DoGetHTTPServer creates an HTTP Server with the provided bind address and router
-func (e *Init) DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer {
+func (e *Init) DoGetHTTPServer(cfg *config.Config, bindAddr string, router http.Handler) HTTPServer {
 	s := dphttp.NewServer(bindAddr, router)
+	s.Server.ReadTimeout = cfg.ReadTimeout
+	s.Server.WriteTimeout = cfg.WriteTimeout
 	s.HandleOSSignals = false
 	return s
 }

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -15,7 +15,7 @@ import (
 
 // Initialiser defines the methods to initialise external services
 type Initialiser interface {
-	DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer
+	DoGetHTTPServer(cfg *config.Config, bindAddr string, router http.Handler) HTTPServer
 	DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, version string) (HealthChecker, error)
 	DoGetRequestMiddleware() RequestMiddleware
 }

--- a/service/mock/initialiser.go
+++ b/service/mock/initialiser.go
@@ -4,11 +4,10 @@
 package mock
 
 import (
-	"net/http"
-	"sync"
-
 	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
 	"github.com/ONSdigital/dp-legacy-cache-proxy/service"
+	"net/http"
+	"sync"
 )
 
 // Ensure, that InitialiserMock does implement service.Initialiser.
@@ -21,7 +20,7 @@ var _ service.Initialiser = &InitialiserMock{}
 //
 //		// make and configure a mocked service.Initialiser
 //		mockedInitialiser := &InitialiserMock{
-//			DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer {
+//			DoGetHTTPServerFunc: func(cfg *config.Config, bindAddr string, router http.Handler) service.HTTPServer {
 //				panic("mock out the DoGetHTTPServer method")
 //			},
 //			DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
@@ -38,7 +37,7 @@ var _ service.Initialiser = &InitialiserMock{}
 //	}
 type InitialiserMock struct {
 	// DoGetHTTPServerFunc mocks the DoGetHTTPServer method.
-	DoGetHTTPServerFunc func(bindAddr string, router http.Handler) service.HTTPServer
+	DoGetHTTPServerFunc func(cfg *config.Config, bindAddr string, router http.Handler) service.HTTPServer
 
 	// DoGetHealthCheckFunc mocks the DoGetHealthCheck method.
 	DoGetHealthCheckFunc func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error)
@@ -50,6 +49,8 @@ type InitialiserMock struct {
 	calls struct {
 		// DoGetHTTPServer holds details about calls to the DoGetHTTPServer method.
 		DoGetHTTPServer []struct {
+			// Cfg is the cfg argument value.
+			Cfg *config.Config
 			// BindAddr is the bindAddr argument value.
 			BindAddr string
 			// Router is the router argument value.
@@ -76,21 +77,23 @@ type InitialiserMock struct {
 }
 
 // DoGetHTTPServer calls DoGetHTTPServerFunc.
-func (mock *InitialiserMock) DoGetHTTPServer(bindAddr string, router http.Handler) service.HTTPServer {
+func (mock *InitialiserMock) DoGetHTTPServer(cfg *config.Config, bindAddr string, router http.Handler) service.HTTPServer {
 	if mock.DoGetHTTPServerFunc == nil {
 		panic("InitialiserMock.DoGetHTTPServerFunc: method is nil but Initialiser.DoGetHTTPServer was just called")
 	}
 	callInfo := struct {
+		Cfg      *config.Config
 		BindAddr string
 		Router   http.Handler
 	}{
+		Cfg:      cfg,
 		BindAddr: bindAddr,
 		Router:   router,
 	}
 	mock.lockDoGetHTTPServer.Lock()
 	mock.calls.DoGetHTTPServer = append(mock.calls.DoGetHTTPServer, callInfo)
 	mock.lockDoGetHTTPServer.Unlock()
-	return mock.DoGetHTTPServerFunc(bindAddr, router)
+	return mock.DoGetHTTPServerFunc(cfg, bindAddr, router)
 }
 
 // DoGetHTTPServerCalls gets all the calls that were made to DoGetHTTPServer.
@@ -98,10 +101,12 @@ func (mock *InitialiserMock) DoGetHTTPServer(bindAddr string, router http.Handle
 //
 //	len(mockedInitialiser.DoGetHTTPServerCalls())
 func (mock *InitialiserMock) DoGetHTTPServerCalls() []struct {
+	Cfg      *config.Config
 	BindAddr string
 	Router   http.Handler
 } {
 	var calls []struct {
+		Cfg      *config.Config
 		BindAddr string
 		Router   http.Handler
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -34,7 +34,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 
 	// TODO: Any middleware will require 'otelhttp.NewMiddleware(cfg.OTServiceName),' included for Open Telemetry
 
-	s := serviceList.GetHTTPServer(cfg.BindAddr, r)
+	s := serviceList.GetHTTPServer(cfg, cfg.BindAddr, r)
 
 	// TODO: Add other(s) to serviceList here
 
@@ -50,7 +50,6 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	}
 
 	r.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)
-
 	// The proxy needs to be set up after the HealthCheck route has been added to the router: in the Setup method, the
 	// proxy adds a catch-all route, so any other routes added after that one will never be reachable.
 	p := proxy.Setup(ctx, r, cfg)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -35,7 +35,7 @@ var funcDoGetHealthcheckErr = func(cfg *config.Config, buildTime string, gitComm
 	return nil, errHealthcheck
 }
 
-var funcDoGetHTTPServerNil = func(bindAddr string, router http.Handler) service.HTTPServer {
+var funcDoGetHTTPServerNil = func(cfg *config.Config, bindAddr string, router http.Handler) service.HTTPServer {
 	return nil
 }
 
@@ -68,11 +68,11 @@ func TestRun(t *testing.T) {
 			return hcMock, nil
 		}
 
-		funcDoGetHTTPServer := func(bindAddr string, router http.Handler) service.HTTPServer {
+		funcDoGetHTTPServer := func(cfg *config.Config, bindAddr string, router http.Handler) service.HTTPServer {
 			return serverMock
 		}
 
-		funcDoGetFailingHTTPServer := func(bindAddr string, router http.Handler) service.HTTPServer {
+		funcDoGetFailingHTTPServer := func(cfg *config.Config, bindAddr string, router http.Handler) service.HTTPServer {
 			return failingServerMock
 		}
 
@@ -227,7 +227,7 @@ func TestClose(t *testing.T) {
 
 		Convey("Closing the service results in all the dependencies being closed in the expected order", func() {
 			initMock := &mock.InitialiserMock{
-				DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer { return serverMock },
+				DoGetHTTPServerFunc: func(cfg *config.Config, bindAddr string, router http.Handler) service.HTTPServer { return serverMock },
 				DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
 					return hcMock, nil
 				},
@@ -254,7 +254,9 @@ func TestClose(t *testing.T) {
 			}
 
 			initMock := &mock.InitialiserMock{
-				DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer { return failingserverMock },
+				DoGetHTTPServerFunc: func(cfg *config.Config, bindAddr string, router http.Handler) service.HTTPServer {
+					return failingserverMock
+				},
 				DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
 					return hcMock, nil
 				},


### PR DESCRIPTION
### What

As a result of the performance testing on staging, io.Copy was throwing a timeout error.

We have increased the read & write timeouts and also added a buffer to the copy method.

### How to review

Inspect code, confirm approach.

To test this properly, JMeter must be configured in same the way it is for the performance tests on staging.

### Who can review

A member of the ONS.
