### PR TITLE
Status code with 302 is not auto-redirected by client

### DIFF
--- a/proxy/manager.go
+++ b/proxy/manager.go
@@ -24,7 +24,11 @@ func (proxy *Proxy) manage(ctx context.Context, w http.ResponseWriter, req *http
 	// Copy headers from original request to proxy request
 	proxyReq.Header = req.Header
 
-	client := &http.Client{}
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 	serviceResponse, err := client.Do(proxyReq)
 
 	if err != nil {


### PR DESCRIPTION
### What

The client wrongly redirected when the status code of the request was 302, this is the default behaviour of http.client in go. 

To fix this, a custom http.client was implemented that ensures that 'CheckRedirect' returns the most recent response with its body, this stops it from automatically following the redirect. 

More information on this can be found here: https://pkg.go.dev/net/http#Client :

`ErrUseLastResponse can be returned by Client.CheckRedirect hooks to control how redirects are processed. If returned, the next request is not sent and the most recent response is returned with its body unclosed.`

### How to review

Run stack locally and then check that when a curl is made to dp-frontend-router to GET on /on/randomsegmentname (/ons/*) endpoints, status code should be 302. Using: curl -i http://localhost:20000/ons/randomsegmentname 

### Who can review

Anyone from ONS
