### PR TITLE
Set short cache time for search URIs

### DIFF
--- a/features/set_cache_time.feature
+++ b/features/set_cache_time.feature
@@ -41,6 +41,17 @@ Feature: Set cache time
     | /fonts/open-sans-regular/OpenSans-Regular-webfont.woff2 |
     | /favicon.ico                                            |
 
+  Scenario Outline: Search URI should have a short cache time
+    When the Proxy receives a GET request for "<search-uri>"
+    Then the response header "Cache-Control" should be "max-age=10"
+  Examples:
+    | search-uri                                              |
+    | /releasecalendar                                        |
+    | /timeseriestool                                         |
+    | /economy/publications                                   |
+    | /business/business/business/datalist                    |
+    | /anothertopic/staticlist                                |
+
   Scenario: Return the errored cache time when the Legacy Cache API returns an error
     Given the Legacy Cache API has an error
     When the Proxy receives a GET request for "/some-path"

--- a/response/max_age.go
+++ b/response/max_age.go
@@ -15,12 +15,17 @@ import (
 const maxAgeErrorMessage = "error calculating the max-age directive"
 
 var versionedURIRegexp = regexp.MustCompile(`/previous/v\d+`)
+var searchPageRegexp = regexp.MustCompile(`\/(allmethodologies|releasecalendar|timeseriestool|datalist|publications|staticlist|topicspecificmethodology|relateddata|alladhocs|publishedrequests)$`)
 
 func maxAge(ctx context.Context, uri string, cfg *config.Config) int {
 	log.Info(ctx, "Calculating max-age for "+uri)
 
 	if isLegacyAssetURI(uri) || isOnsURI(uri) || isVersionedURI(uri) {
 		return int(cfg.CacheTimeLong.Seconds())
+	}
+
+	if isSearchPageURI(uri) {
+		return int(cfg.CacheTimeShort.Seconds())
 	}
 
 	pagePath, err := getPagePath(ctx, uri)
@@ -86,4 +91,8 @@ func isVersionedURI(uri string) bool {
 
 func wasReleasedRecently(releaseTime time.Time, offset time.Duration) bool {
 	return releaseTime.Add(offset).After(time.Now())
+}
+
+func isSearchPageURI(uri string) bool {
+	return searchPageRegexp.MatchString(uri)
 }

--- a/response/max_age_test.go
+++ b/response/max_age_test.go
@@ -62,6 +62,34 @@ func TestMaxAgeLongCacheTime(t *testing.T) {
 	})
 }
 
+func TestMaxAgeShortCacheTime(t *testing.T) {
+	Convey("Given a list of URIs and a pre-configured short cache time", t, func() {
+		ctx := context.Background()
+		const shortCacheTime = 5
+		cfg := &config.Config{
+			CacheTimeShort: time.Duration(shortCacheTime) * time.Second,
+		}
+
+		searchURIs := []string{
+			"/releasecalendar",
+			"/publications",
+			"/economy/datalist",
+			"/business/anotherbusiness/allmethodologies",
+			"/timeseriestool",
+		}
+
+		Convey("When the 'maxAge' function is called", func() {
+			for _, uri := range searchURIs {
+				result := maxAge(ctx, uri, cfg)
+
+				Convey("Then it should return a short cache time for the following URI: "+uri, func() {
+					So(result, ShouldEqual, shortCacheTime)
+				})
+			}
+		})
+	})
+}
+
 func TestMaxAgeInteractionWithLegacyCacheAPI(t *testing.T) {
 	Convey("Given a Legacy Cache API and some pre-configured cache time values", t, func() {
 		ctx := context.Background()


### PR DESCRIPTION
### What

Added short cache time for search urls from babbage

### How to review

Check tests and code ok. Otherwise, portforward to babbage in sandbox and hit a search url and see the max-age 10 come back

### Who can review

Not me. 