### PR TITLE
Issue short cache for search pages with queries

### DIFF
--- a/response/max_age.go
+++ b/response/max_age.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -94,5 +95,10 @@ func wasReleasedRecently(releaseTime time.Time, offset time.Duration) bool {
 }
 
 func isSearchPageURI(uri string) bool {
-	return searchPageRegexp.MatchString(uri)
+	urlToTest, err := url.Parse(uri)
+	if err != nil {
+		return false
+	}
+
+	return searchPageRegexp.MatchString(urlToTest.Path)
 }

--- a/response/max_age_test.go
+++ b/response/max_age_test.go
@@ -72,6 +72,7 @@ func TestMaxAgeShortCacheTime(t *testing.T) {
 
 		searchURIs := []string{
 			"/releasecalendar",
+			"/releasecalendar?view=upcoming",
 			"/publications",
 			"/economy/datalist",
 			"/business/anotherbusiness/allmethodologies",


### PR DESCRIPTION
### What

Set short cache time for searchpages including query params / anchor links etc. 

### How to review

Check ok, tests ok. 

Optionally:

Port forward to Babbage and dp-legacy-cache-api in sandbox web. 
Run service
Hit /releasecalendar?view=upcoming
See cache time

### Who can review

Not me. 