### PR TITLE
change behaviour on a 304 from babbage: we now add cache-control header

### DIFF
--- a/features/set_cache_time.feature
+++ b/features/set_cache_time.feature
@@ -52,6 +52,20 @@ Feature: Set cache time
     | /business/business/business/datalist                    |
     | /anothertopic/staticlist                                |
 
+  Scenario Outline: The response from Babbage is 304 so we set Cache-Control header
+    Given Babbage will send the following response with status "304":
+      """
+      """
+    And Babbage will set the "X-Some-Header" header to "some-value"
+    When the Proxy receives a GET request for "<sample-uri>"
+    Then the response header "Cache-Control" should be "max-age=<max-age>"
+    And the HTTP status code should be "304"
+  Examples:
+    | sample-uri                                              | max-age |
+    | /some-url                                               |     900 |
+    | /releasecalendar                                        |      10 |
+    | /favicon.ico                                            |   14400 |
+
   Scenario: Return the errored cache time when the Legacy Cache API returns an error
     Given the Legacy Cache API has an error
     When the Proxy receives a GET request for "/some-path"

--- a/features/unmodified_response.feature
+++ b/features/unmodified_response.feature
@@ -81,14 +81,6 @@ Feature: Unmodified response
     | 510         |
     | 511         |
 
-  Scenario: The status code from Babbage is 304 (Not Modified)
-    Given Babbage will set the HTTP status code to "304"
-    And Babbage will set the "ETag" header to "abc123"
-    And Babbage will set the "Referrer-Policy" header to "origin"
-    When the Proxy receives a GET request for "/"
-    Then I should receive an empty response
-    And I should receive the same, unmodified response from Babbage
-
   Scenario Outline: The response from Babbage is not cacheable (based on its Cache-Control header)
     Given Babbage will send the following response with status "200":
       """

--- a/response/writer.go
+++ b/response/writer.go
@@ -73,7 +73,7 @@ func isGetOrHead(method string) bool {
 }
 
 func isCacheableStatusCode(statusCode int) bool {
-	return statusCode < 300 || statusCode == 404
+	return statusCode < 300 || statusCode == 304 || statusCode == 404
 }
 
 func shouldCalculateMaxAge(cacheControlValue string) bool {


### PR DESCRIPTION
### What

change behaviour on a 304 (Not Modified) from babbage: we now add cache-control header

### How to review

ensure a babbage 304 has a `Cache-control` header appropriate for the page

### Who can review

!me
