### PR TITLE
Add bulletin extensions for proxying

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,30 +21,32 @@ directives in the `Cache-Control` header to appropriate values.
 
 ### Configuration
 
-| Environment variable           | Default                  | Description
-|--------------------------------|--------------------------|------------
-| BIND_ADDR                      | :29200                   | The host and port to bind to
-| GRACEFUL_SHUTDOWN_TIMEOUT      | 5s                       | The graceful shutdown timeout[^gotime]
-| HEALTHCHECK_INTERVAL           | 30s                      | Time between self-healthchecks[^gotime]
-| HEALTHCHECK_CRITICAL_TIMEOUT   | 90s                      | Time duration[^gotime] to wait until an unhealthy dependent propagates its state to make this app unhealthy
-| HTTP_MAX_CONNECTIONS           | 0                        | Limit the number of concurrent http connections (0 = unlimited)
-| OTEL_BATCH_TIMEOUT             | 5s                       | Time duration[^gotime] after which a batch will be sent regardless of size
-| OTEL_EXPORTER_OTLP_ENDPOINT    | localhost:4317           | OpenTelemetry Exporter address
-| OTEL_SERVICE_NAME              | dp-legacy-cache-proxy    | The name of this service in OpenTelemetry
-| OTEL_ENABLED                   | false                    | Turn OTEL on / off
-| BABBAGE_URL                    | `http://localhost:8080`  | Babbage address, where all the incoming requests are forwarded to
-| LEGACY_CACHE_API_URL           | `http://localhost:29100` | Legacy Cache API address
-| RELEASE_CALENDAR_URL           | `http://localhost:27700` | Release calendar frontend controller address
-| CACHE_TIME_DEFAULT             | 15m                      | Default value[^gotime] for `max-age`[^cachedir]
-| CACHE_TIME_ERRORED             | 30s                      | Errored value[^gotime] for `max-age`[^cachedir]
-| CACHE_TIME_LONG                | 4h                       | Long value[^gotime] for `max-age`[^cachedir]
-| CACHE_TIME_SHORT               | 10s                      | Short value[^gotime] for `max-age`[^cachedir]
-| ENABLE_PUBLISH_EXPIRY_OFFSET   | false                    | Determines if publish expiry offset is used which enables a shorter cache time for recently published content
-| PUBLISH_EXPIRY_OFFSET          | 3m                       | Period of time[^gotime] after a release in which the proxy needs to return a short value for `max-age` [^cachedir]
-| READ_TIMEOUT                   | 15s                      | Maximum time[^gotime] the server will wait for a client to send a complete request
-| WRITE_TIMEOUT                  | 30s                      | Maximum time[^gotime] the server will wait while trying to write a response to the client
-| STALE_WHILE_REVALIDATE_SECONDS | -1                       | If non-negative, add the `stale-while-revalidate` option (using this number as the *seconds* value) to any `Cache-control` header responses
-| ENABLE_MAX_AGE_COUNTDOWN       | true                     | During the countdown to a release time: if this is *true*, `max-age` value will countdown; if *false*, `max-age=0` is used
+| Environment variable           | Default                   | Description
+|--------------------------------|---------------------------|------------
+| BIND_ADDR                      | :29200                    | The host and port to bind to
+| GRACEFUL_SHUTDOWN_TIMEOUT      | 5s                        | The graceful shutdown timeout[^gotime]
+| HEALTHCHECK_INTERVAL           | 30s                       | Time between self-healthchecks[^gotime]
+| HEALTHCHECK_CRITICAL_TIMEOUT   | 90s                       | Time duration[^gotime] to wait until an unhealthy dependent propagates its state to make this app unhealthy
+| HTTP_MAX_CONNECTIONS           | 0                         | Limit the number of concurrent http connections (0 = unlimited)
+| OTEL_BATCH_TIMEOUT             | 5s                        | Time duration[^gotime] after which a batch will be sent regardless of size
+| OTEL_EXPORTER_OTLP_ENDPOINT    | localhost:4317            | OpenTelemetry Exporter address
+| OTEL_SERVICE_NAME              | dp-legacy-cache-proxy     | The name of this service in OpenTelemetry
+| OTEL_ENABLED                   | false                     | Turn OTEL on / off
+| BABBAGE_URL                    | `http://localhost:8080`   | Babbage address, where most of the incoming requests are forwarded to
+| LEGACY_CACHE_API_URL           | `http://localhost:29100`  | Legacy Cache API address
+| RELEASE_CALENDAR_URL           | `http://localhost:27700`  | Release calendar frontend controller address
+| CACHE_TIME_DEFAULT             | 15m                       | Default value[^gotime] for `max-age`[^cachedir]
+| CACHE_TIME_ERRORED             | 30s                       | Errored value[^gotime] for `max-age`[^cachedir]
+| CACHE_TIME_LONG                | 4h                        | Long value[^gotime] for `max-age`[^cachedir]
+| CACHE_TIME_SHORT               | 10s                       | Short value[^gotime] for `max-age`[^cachedir]
+| ENABLE_PUBLISH_EXPIRY_OFFSET   | false                     | Determines if publish expiry offset is used which enables a shorter cache time for recently published content
+| PUBLISH_EXPIRY_OFFSET          | 3m                        | Period of time[^gotime] after a release in which the proxy needs to return a short value for `max-age` [^cachedir]
+| READ_TIMEOUT                   | 15s                       | Maximum time[^gotime] the server will wait for a client to send a complete request
+| WRITE_TIMEOUT                  | 30s                       | Maximum time[^gotime] the server will wait while trying to write a response to the client
+| STALE_WHILE_REVALIDATE_SECONDS | -1                        | If non-negative, add the `stale-while-revalidate` option (using this number as the *seconds* value) to any `Cache-control` header responses
+| ENABLE_MAX_AGE_COUNTDOWN       | true                      | During the countdown to a release time: if this is *true*, `max-age` value will countdown; if *false*, `max-age=0` is used
+| ENABLE_SEARCH_CONTROLLER       | false                     | Enable routing to search controller
+| SEARCH_CONTROLLER_URL          | `http://localhost:25000`  | Search controller address, where previousreleases and relateddata requests are forwarded to
 
 [^gotime]: using golang's `time.Duration` format
 [^cachedir]: a directive of the `Cache-Control` header

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	OTServiceName               string        `envconfig:"OTEL_SERVICE_NAME"`
 	BabbageURL                  string        `envconfig:"BABBAGE_URL"`
 	RelCalURL                   string        `envconfig:"RELEASE_CALENDAR_URL"`
+	EnableSearchController      bool          `envconfig:"ENABLE_SEARCH_CONTROLLER"`
+	SearchControllerURL         string        `envconfig:"SEARCH_CONTROLLER_URL"`
 	LegacyCacheAPIURL           string        `envconfig:"LEGACY_CACHE_API_URL"`
 	CacheTimeDefault            time.Duration `envconfig:"CACHE_TIME_DEFAULT"`
 	CacheTimeErrored            time.Duration `envconfig:"CACHE_TIME_ERRORED"`
@@ -53,6 +55,8 @@ func Get() (*Config, error) {
 		BabbageURL:                  "http://localhost:8080",
 		LegacyCacheAPIURL:           "http://localhost:29100",
 		RelCalURL:                   "http://localhost:27700",
+		SearchControllerURL:         "http://localhost:25000",
+		EnableSearchController:      false,
 		CacheTimeDefault:            15 * time.Minute,
 		CacheTimeErrored:            30 * time.Second,
 		CacheTimeLong:               4 * time.Hour,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,6 +34,7 @@ func TestConfig(t *testing.T) {
 					BabbageURL:                  "http://localhost:8080",
 					LegacyCacheAPIURL:           "http://localhost:29100",
 					RelCalURL:                   "http://localhost:27700",
+					SearchControllerURL:         "http://localhost:25000",
 					CacheTimeDefault:            15 * time.Minute,
 					CacheTimeErrored:            30 * time.Second,
 					CacheTimeLong:               4 * time.Hour,
@@ -45,6 +46,7 @@ func TestConfig(t *testing.T) {
 					StaleWhileRevalidateSeconds: -1,
 					EnableMaxAgeCountdown:       true,
 					OtelEnabled:                 false,
+					EnableSearchController:      false,
 				})
 			})
 

--- a/features/search_controller_response.feature
+++ b/features/search_controller_response.feature
@@ -1,0 +1,35 @@
+Feature: Proxy returns response from Search Controller
+
+    The proxy can be called with Search Controller URLs (for instance, "/economy/economicoutputandproductivity/productivitymeasures/articles/gdpandthelabourmarket/previousreleases"),
+    when this happens we want to ensure that the proxy forwards the URL to the Search Controller. 
+
+  Background:
+    Given config includes ENABLE_SEARCH_CONTROLLER with a value of "true"
+
+  Scenario: Proxy returns response from Search Controller with stale-while-revalidate
+    Given Search Controller will send the following response with status "200":
+      """
+      Mock response from Search Controller
+      """
+    And config includes STALE_WHILE_REVALIDATE_SECONDS with a value of "31"
+    When the Proxy receives a GET request for "/economy/economicoutputandproductivity/productivitymeasures/articles/gdpandthelabourmarket/previousreleases"
+    Then the response header "Cache-Control" should be "public, s-maxage=900, max-age=900, stale-while-revalidate=31"
+    And the HTTP status code should be "200"
+    And I should receive the following response:
+      """
+      Mock response from Search Controller
+      """
+
+  Scenario: Proxy returns response from Search Controller without stale-while-revalidate
+    Given Search Controller will send the following response with status "200":
+      """
+      Mock response from Search Controller
+      """
+    And config includes STALE_WHILE_REVALIDATE_SECONDS with a value of "-1"
+    When the Proxy receives a GET request for "/economy/economicoutputandproductivity/productivitymeasures/articles/gdpandthelabourmarket/previousreleases"
+    Then the response header "Cache-Control" should be "public, s-maxage=900, max-age=900"
+    And the HTTP status code should be "200"
+    And I should receive the following response:
+      """
+      Mock response from Search Controller
+      """

--- a/features/steps/proxy_component.go
+++ b/features/steps/proxy_component.go
@@ -16,16 +16,17 @@ import (
 
 type Component struct {
 	componenttest.ErrorFeature
-	svcList                *service.ExternalServiceList
-	svc                    *service.Service
-	errorChan              chan error
-	Config                 *config.Config
-	HTTPServer             *http.Server
-	ServiceRunning         bool
-	apiFeature             *componenttest.APIFeature
-	babbageFeature         *BabbageFeature
-	legacyCacheAPIFeature  *LegacyCacheAPIFeature
-	releaseCalendarFeature *ReleaseCalendarFeature
+	svcList                 *service.ExternalServiceList
+	svc                     *service.Service
+	errorChan               chan error
+	Config                  *config.Config
+	HTTPServer              *http.Server
+	ServiceRunning          bool
+	apiFeature              *componenttest.APIFeature
+	babbageFeature          *BabbageFeature
+	legacyCacheAPIFeature   *LegacyCacheAPIFeature
+	releaseCalendarFeature  *ReleaseCalendarFeature
+	searchControllerFeature *SearchControllerFeature
 }
 
 func NewComponent() (*Component, error) {
@@ -44,10 +45,12 @@ func NewComponent() (*Component, error) {
 	c.babbageFeature = NewBabbageFeature()
 	c.legacyCacheAPIFeature = NewLegacyCacheAPIFeature()
 	c.releaseCalendarFeature = NewReleaseCalendarFeature()
+	c.searchControllerFeature = NewSearchControllerFeature()
 
 	c.Config.BabbageURL = c.babbageFeature.Server.URL
 	c.Config.LegacyCacheAPIURL = c.legacyCacheAPIFeature.Server.URL
 	c.Config.RelCalURL = c.releaseCalendarFeature.Server.URL
+	c.Config.SearchControllerURL = c.searchControllerFeature.Server.URL
 	c.Config.EnablePublishExpiryOffset = true
 
 	initMock := &mock.InitialiserMock{
@@ -74,6 +77,7 @@ func (c *Component) Close() error {
 		c.babbageFeature.Server.Close()
 		c.legacyCacheAPIFeature.Server.Close()
 		c.releaseCalendarFeature.Server.Close()
+		c.searchControllerFeature.Server.Close()
 		if err := c.svc.Close(context.Background()); err != nil {
 			return err
 		}

--- a/features/steps/search_feature.go
+++ b/features/steps/search_feature.go
@@ -1,0 +1,63 @@
+package steps
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+
+	"github.com/cucumber/godog"
+)
+
+type SearchControllerFeature struct {
+	Server     *httptest.Server
+	Body       string
+	StatusCode int
+	Headers    map[string]string
+}
+
+func NewSearchControllerFeature() *SearchControllerFeature {
+	f := SearchControllerFeature{
+		Headers: make(map[string]string),
+	}
+
+	f.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		for headerName, headerValue := range f.Headers {
+			w.Header().Set(headerName, headerValue)
+		}
+
+		w.WriteHeader(f.StatusCode)
+
+		if _, err := w.Write([]byte(f.Body)); err != nil {
+			panic(err)
+		}
+	}))
+
+	return &f
+}
+
+func (f *SearchControllerFeature) RegisterSteps(ctx *godog.ScenarioContext) {
+	ctx.Step(`^Search Controller will send the following response:$`, f.searchControllerWillSendTheFollowingResponse)
+	ctx.Step(`^Search Controller will send the following response with status "([^"]*)":$`, f.searchControllerWillSendTheFollowingResponseWithStatus)
+}
+
+func (f *SearchControllerFeature) searchControllerWillSendTheFollowingResponse(babbageBody *godog.DocString) error {
+	return f.searchControllerWillSendTheFollowingResponseWithStatus("200", babbageBody)
+}
+
+func (f *SearchControllerFeature) searchControllerWillSendTheFollowingResponseWithStatus(statusCodeStr string, searchControllerBody *godog.DocString) error {
+	f.Body = strings.TrimSpace(searchControllerBody.Content)
+
+	return f.searchControllerWillSetTheHTTPStatusCodeTo(statusCodeStr)
+}
+
+func (f *SearchControllerFeature) searchControllerWillSetTheHTTPStatusCodeTo(statusCodeStr string) error {
+	statusCode, err := strconv.Atoi(statusCodeStr)
+	if err != nil {
+		return err
+	}
+
+	f.StatusCode = statusCode
+
+	return nil
+}

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -26,6 +26,7 @@ func (c *Component) RegisterSteps(ctx *godog.ScenarioContext) {
 	c.babbageFeature.RegisterSteps(ctx)
 	c.legacyCacheAPIFeature.RegisterSteps(ctx)
 	c.releaseCalendarFeature.RegisterSteps(ctx)
+	c.searchControllerFeature.RegisterSteps(ctx)
 
 	ctx.Step(`^I should receive an empty response$`, c.iShouldReceiveAnEmptyResponse)
 	ctx.Step(`^I should receive the same, unmodified response from Babbage$`, c.iShouldReceiveTheSameUnmodifiedResponseFromBabbage)
@@ -58,6 +59,12 @@ func (c *Component) configIncludes(configItem, configVal string) error {
 			return err
 		}
 		c.Config.EnableMaxAgeCountdown = isEnabled
+	case "ENABLE_SEARCH_CONTROLLER":
+		isEnabled, err := strconv.ParseBool(configVal)
+		if err != nil {
+			return err
+		}
+		c.Config.EnableSearchController = isEnabled
 	default:
 		return fmt.Errorf("not a valid config item")
 	}

--- a/proxy/manager.go
+++ b/proxy/manager.go
@@ -53,9 +53,15 @@ func IsReleaseCalendarURL(url string) bool {
 	return strings.HasPrefix(url, "/releases/")
 }
 
+func IsSearchControllerURL(url string) bool {
+	return (strings.HasSuffix(url, "/previousreleases") || strings.HasSuffix(url, "/relatedData") || strings.HasSuffix(url, "/relateddata"))
+}
+
 func getTargetURL(requestURL string, cfg *config.Config) string {
 	if IsReleaseCalendarURL(requestURL) {
 		return cfg.RelCalURL + requestURL
+	} else if IsSearchControllerURL(requestURL) && cfg.EnableSearchController {
+		return cfg.SearchControllerURL + requestURL
 	}
 	return cfg.BabbageURL + requestURL
 }

--- a/proxy/manager_test.go
+++ b/proxy/manager_test.go
@@ -11,6 +11,30 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+var (
+	releaseCalendarURLs = []string{
+		"/releases/greenjobscurrentandupcomingworkmarch2022",
+		"/releases/post2019westminsterparliamentaryconstituenciesandseneddelectoralregionsdataenglandandwalescensus2021",
+		"/releases/mycollectionpage1",
+		"/releases/timespentinnature",
+		"/releases/constructionstatisticsgreatbritain2022",
+	}
+
+	babbageURLs = []string{
+		"/visualisations/dvc1945/seasonalflu/index.html",
+		"/generator?uri=/economy/economicoutputandproductivity/output/bulletins/economicactivityandsocialchangeintheukrealtimeindicators/15february2024/426e63a0&format=csv",
+		"/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest",
+		"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/linechartconfig",
+		"/businessindustryandtrade/changestobusiness/mergersandacquisitions/datasets/timeseries/15march2024",
+	}
+
+	searchControllerURLs = []string{
+		"/economy/previousreleases",
+		"/businessindustryandtrade/changestobusiness/mergersandacquisitions/relatedData",
+		"/economy/economicoutputandproductivity/output/bulletins/economicactivityandsocialchangeintheukrealtimeindicators/relateddata",
+	}
+)
+
 func TestProxyHandleRequestOK(t *testing.T) {
 	Convey("Given a Proxy and a Babbage server", t, func() {
 		mockBabbageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -93,16 +117,67 @@ func TestProxyHandleRequestError(t *testing.T) {
 	})
 }
 
+func TestProxyHandleRoutingSearch(t *testing.T) {
+	Convey("Given a Proxy and an enabled Search Controller", t, func() {
+		mockSearchServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("mock-header", "test")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("Mock Search Response"))
+			if err != nil {
+				panic(err)
+			}
+		}))
+		defer mockSearchServer.Close()
+		ctx := context.Background()
+		router := mux.NewRouter()
+		cfg := &config.Config{SearchControllerURL: mockSearchServer.URL, EnableSearchController: true}
+
+		legacyCacheProxy := Setup(ctx, router, cfg)
+
+		Convey("When a search request is sent", func() {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/test-endpoint/previousreleases", http.NoBody)
+			legacyCacheProxy.Router.ServeHTTP(w, r)
+
+			Convey("Then the proxy response should match the Search response", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Body.String(), ShouldEqual, "Mock Search Response")
+				So(w.Header().Get("mock-header"), ShouldEqual, "test")
+			})
+		})
+	})
+
+	Convey("Given a Proxy, a mock Babbage and Search Controller Proxying is disabled", t, func() {
+		mockBabbageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("mock-header", "test")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("Mock Babbage Response"))
+			if err != nil {
+				panic(err)
+			}
+		}))
+		defer mockBabbageServer.Close()
+		ctx := context.Background()
+		router := mux.NewRouter()
+		cfg := &config.Config{BabbageURL: mockBabbageServer.URL, EnableSearchController: false}
+
+		legacyCacheProxy := Setup(ctx, router, cfg)
+
+		Convey("When a search request is sent", func() {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/test-endpoint/previousreleases", http.NoBody)
+			legacyCacheProxy.Router.ServeHTTP(w, r)
+
+			Convey("Then the proxy response should match the Babbage response", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Body.String(), ShouldEqual, "Mock Babbage Response")
+				So(w.Header().Get("mock-header"), ShouldEqual, "test")
+			})
+		})
+	})
+}
 func TestIsReleaseCalendarURL(t *testing.T) {
 	Convey("Given a list of release calendar URLs", t, func() {
-		releaseCalendarURLs := []string{
-			"/releases/greenjobscurrentandupcomingworkmarch2022",
-			"/releases/post2019westminsterparliamentaryconstituenciesandseneddelectoralregionsdataenglandandwalescensus2021",
-			"/releases/mycollectionpage1",
-			"/releases/timespentinnature",
-			"/releases/constructionstatisticsgreatbritain2022",
-		}
-
 		Convey("When the 'IsReleaseCalendarURL' function is called", func() {
 			for _, url := range releaseCalendarURLs {
 				isReleaseCalendar := IsReleaseCalendarURL(url)
@@ -114,20 +189,49 @@ func TestIsReleaseCalendarURL(t *testing.T) {
 		})
 	})
 	Convey("Given a list of babbage URLs", t, func() {
-		babbageURLs := []string{
-			"/visualisations/dvc1945/seasonalflu/index.html",
-			"/generator?uri=/economy/economicoutputandproductivity/output/bulletins/economicactivityandsocialchangeintheukrealtimeindicators/15february2024/426e63a0&format=csv",
-			"/economy/inflationandpriceindices/bulletins/producerpriceinflation/latest",
-			"/economy/grossdomesticproductgdp/timeseries/abmi/pn2/linechartconfig",
-			"/businessindustryandtrade/changestobusiness/mergersandacquisitions/datasets/timeseries/15march2024",
-		}
-
 		Convey("When the 'IsReleaseCalendarURL' function is called", func() {
 			for _, url := range babbageURLs {
 				isReleaseCalendar := IsReleaseCalendarURL(url)
 
 				Convey("Then it should evaluate to false for "+url, func() {
 					So(isReleaseCalendar, ShouldBeFalse)
+				})
+			}
+		})
+	})
+}
+
+func TestIsSearchControllerURL(t *testing.T) {
+	Convey("Given a list of search controller URLs", t, func() {
+		Convey("When the 'IsSearchControllerURL' function is called", func() {
+			for _, url := range searchControllerURLs {
+				isSearchController := IsSearchControllerURL(url)
+
+				Convey("Then it should evaluate to true for "+url, func() {
+					So(isSearchController, ShouldBeTrue)
+				})
+			}
+		})
+	})
+	Convey("Given a list of babbage URLs", t, func() {
+		Convey("When the 'IsSearchControllerURL' function is called", func() {
+			for _, url := range babbageURLs {
+				isSearchController := IsSearchControllerURL(url)
+
+				Convey("Then it should evaluate to false for "+url, func() {
+					So(isSearchController, ShouldBeFalse)
+				})
+			}
+		})
+	})
+
+	Convey("Given a list of release calendar URLs", t, func() {
+		Convey("When the 'IsSearchControllerURL' function is called", func() {
+			for _, url := range releaseCalendarURLs {
+				isSearchController := IsSearchControllerURL(url)
+
+				Convey("Then it should evaluate to false for "+url, func() {
+					So(isSearchController, ShouldBeFalse)
 				})
 			}
 		})

--- a/response/max_age_test.go
+++ b/response/max_age_test.go
@@ -63,36 +63,6 @@ func TestMaxAgeLongCacheTime(t *testing.T) {
 	})
 }
 
-func TestMaxAgeShortCacheTime(t *testing.T) {
-	Convey("Given a list of URIs and a pre-configured short cache time", t, func() {
-		ctx := context.Background()
-		const shortCacheTime = 5
-		cfg := &config.Config{
-			CacheTimeShort: time.Duration(shortCacheTime) * time.Second,
-		}
-
-		searchURIs := []string{
-			"/releasecalendar",
-			"/releasecalendar?view=upcoming",
-			"/publications",
-			"/economy/datalist",
-			"/business/anotherbusiness/allmethodologies",
-			"/timeseriestool",
-		}
-
-		Convey("When the 'maxAge' function is called", func() {
-			for _, uri := range searchURIs {
-				result, isCalculated := maxAge(ctx, uri, cfg)
-
-				Convey("Then it should return a short cache time for the following URI: "+uri, func() {
-					So(result, ShouldEqual, shortCacheTime)
-					So(isCalculated, ShouldBeFalse)
-				})
-			}
-		})
-	})
-}
-
 func TestMaxAgeInteractionWithLegacyCacheAPI(t *testing.T) {
 	Convey("Given a Legacy Cache API and some pre-configured cache time values", t, func() {
 		ctx := context.Background()

--- a/response/page_path.go
+++ b/response/page_path.go
@@ -14,6 +14,7 @@ var (
 
 	visualisationsEndpointRegexp          = regexp.MustCompile(`(^/visualisations/[^/]+)/`)
 	bulletinsOrArticlesPathRegexp         = regexp.MustCompile(`(.+/(bulletins|articles)(?:/[^/]+){2})`)
+	relatedDataRegexp                     = regexp.MustCompile(`/related[Dd]ata$`)
 	methodologiesOrQMIsOrAdHocsPathRegexp = regexp.MustCompile(`.+/(methodologies|qmis|adhocs)/([^/]+)`)
 	fileNameWithExtensionRegexp           = regexp.MustCompile(`(.*)/[^/]+\.\w+$`)
 	timeSeriesPathRegexp                  = regexp.MustCompile(`(.+/timeseries(?:/[^/]+){0,2})`)
@@ -105,10 +106,22 @@ func resolveBulletinsOrArticlesPath(uri string) (string, bool) {
 	match := bulletinsOrArticlesPathRegexp.FindStringSubmatch(uri)
 
 	if len(match) == 3 {
-		return match[1], true
+		return resolveBulletinsOrArticlesExtensionPath(match[1]), true
 	}
 
 	return "", false
+}
+
+func resolveBulletinsOrArticlesExtensionPath(uri string) string {
+	if strings.HasSuffix(uri, "/previousreleases") {
+		return strings.TrimSuffix(uri, "/previousreleases") + "/latest"
+	}
+
+	if relatedDataRegexp.MatchString(uri) {
+		return relatedDataRegexp.ReplaceAllString(uri, "")
+	}
+
+	return uri
 }
 
 func resolveMethodologiesQMIsOrAdHocsPath(uri string) (string, bool) {

--- a/response/page_path_test.go
+++ b/response/page_path_test.go
@@ -146,6 +146,10 @@ func TestGetPagePath(t *testing.T) {
 				expected: "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/latest",
 			},
 			{
+				uri:      "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/latest/data",
+				expected: "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/latest",
+			},
+			{
 				uri:      "/economy/inflationandpriceindices/articles/costofliving/latestinsights",
 				expected: "/economy/inflationandpriceindices/articles/costofliving/latestinsights",
 			},
@@ -156,6 +160,18 @@ func TestGetPagePath(t *testing.T) {
 			{
 				uri:      "/segment-0/articles/segment-1/segment-2/segment-3/",
 				expected: "/segment-0/articles/segment-1/segment-2",
+			},
+			{
+				uri:      "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/previousreleases",
+				expected: "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/latest",
+			},
+			{
+				uri:      "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023/relateddata",
+				expected: "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023",
+			},
+			{
+				uri:      "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023/relatedData",
+				expected: "/economy/inflationandpriceindices/articles/researchanddevelopmentsinthetransformationofukconsumerpricestatistics/december2023",
 			},
 		}
 		methodologiesPaths := []TestCase{


### PR DESCRIPTION
### What

Adding cache calculation for bulletin/article/compenia extension pages (/previousreleases & /related[Dd]ata).
I've also removed previous legacy cache settings for aggregated data pages as these have now all moved to the search service. 

### How to review

Check looks ok, tests pass, sufficient coverage, sensible approach.

Can test locally by running publishing stack and publishing a bulletin and then checking the headers received on the web stack version match the countdown for /relateddata and /previousreleases pages

### Who can review

Not me. 