### PR TITLE
Ensure query param pages route to search controller

### DIFF
--- a/features/search_controller_response.feature
+++ b/features/search_controller_response.feature
@@ -20,6 +20,20 @@ Feature: Proxy returns response from Search Controller
       Mock response from Search Controller
       """
 
+ Scenario: Proxy returns response from Search Controller with stale-while-revalidate with query string
+    Given Search Controller will send the following response with status "200":
+      """
+      Mock response from Search Controller
+      """
+    And config includes STALE_WHILE_REVALIDATE_SECONDS with a value of "31"
+    When the Proxy receives a GET request for "/economy/economicoutputandproductivity/productivitymeasures/articles/gdpandthelabourmarket/previousreleases?page=2"
+    Then the response header "Cache-Control" should be "public, s-maxage=900, max-age=900, stale-while-revalidate=31"
+    And the HTTP status code should be "200"
+    And I should receive the following response:
+      """
+      Mock response from Search Controller
+      """
+
   Scenario: Proxy returns response from Search Controller without stale-while-revalidate
     Given Search Controller will send the following response with status "200":
       """
@@ -33,3 +47,18 @@ Feature: Proxy returns response from Search Controller
       """
       Mock response from Search Controller
       """
+
+  Scenario: Proxy returns response from Search Controller without stale-while-revalidate when it has a query string
+    Given Search Controller will send the following response with status "200":
+      """
+      Mock response from Search Controller
+      """
+    And config includes STALE_WHILE_REVALIDATE_SECONDS with a value of "-1"
+    When the Proxy receives a GET request for "/economy/economicoutputandproductivity/productivitymeasures/articles/gdpandthelabourmarket/previousreleases?page=1"
+    Then the response header "Cache-Control" should be "public, s-maxage=900, max-age=900"
+    And the HTTP status code should be "200"
+    And I should receive the following response:
+      """
+      Mock response from Search Controller
+      """
+

--- a/proxy/manager.go
+++ b/proxy/manager.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
@@ -49,12 +50,16 @@ func (proxy *Proxy) manage(ctx context.Context, w http.ResponseWriter, req *http
 	response.WriteResponse(ctx, w, serviceResponse, req, cfg)
 }
 
-func IsReleaseCalendarURL(url string) bool {
-	return strings.HasPrefix(url, "/releases/")
+func IsReleaseCalendarURL(requestURLstring string) bool {
+	return strings.HasPrefix(requestURLstring, "/releases/")
 }
 
-func IsSearchControllerURL(url string) bool {
-	return (strings.HasSuffix(url, "/previousreleases") || strings.HasSuffix(url, "/relatedData") || strings.HasSuffix(url, "/relateddata"))
+func IsSearchControllerURL(requestURLstring string) bool {
+	requestURL, err := url.Parse(requestURLstring)
+	if err != nil {
+		return false
+	}
+	return (strings.HasSuffix(requestURL.EscapedPath(), "/previousreleases") || strings.HasSuffix(requestURL.EscapedPath(), "/relatedData") || strings.HasSuffix(requestURL.EscapedPath(), "/relateddata"))
 }
 
 func getTargetURL(requestURL string, cfg *config.Config) string {

--- a/proxy/manager_test.go
+++ b/proxy/manager_test.go
@@ -145,6 +145,18 @@ func TestProxyHandleRoutingSearch(t *testing.T) {
 				So(w.Header().Get("mock-header"), ShouldEqual, "test")
 			})
 		})
+
+		Convey("When a search request is sent with a query param", func() {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/test-endpoint/previousreleases?page=2", http.NoBody)
+			legacyCacheProxy.Router.ServeHTTP(w, r)
+
+			Convey("Then the proxy response should match the Search response", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Body.String(), ShouldEqual, "Mock Search Response")
+				So(w.Header().Get("mock-header"), ShouldEqual, "test")
+			})
+		})
 	})
 
 	Convey("Given a Proxy, a mock Babbage and Search Controller Proxying is disabled", t, func() {
@@ -166,6 +178,18 @@ func TestProxyHandleRoutingSearch(t *testing.T) {
 		Convey("When a search request is sent", func() {
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodGet, "/test-endpoint/previousreleases", http.NoBody)
+			legacyCacheProxy.Router.ServeHTTP(w, r)
+
+			Convey("Then the proxy response should match the Babbage response", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+				So(w.Body.String(), ShouldEqual, "Mock Babbage Response")
+				So(w.Header().Get("mock-header"), ShouldEqual, "test")
+			})
+		})
+
+		Convey("When a search request is sent with a query param", func() {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/test-endpoint/previousreleases?page=2", http.NoBody)
 			legacyCacheProxy.Router.ServeHTTP(w, r)
 
 			Convey("Then the proxy response should match the Babbage response", func() {


### PR DESCRIPTION
### What

Ensure bulletin extension pages route to search controller

### How to review

Check ok, tests pass. 

Alternatively you can run:

- dp-frontend-search-controller (and dp-design-system)
- dp-frontend-router (ensure previous releases and related data are switched on, and the proxy)
- dp-legacy-cache-proxy (ensure ENABLE_SEARCH_CONTROLLER is set to true)

Port forward the api-router to sandbox.

Then make a request to a previous releases or related data page and use the pagination.

### Who can review

Not me. 