### PR TITLE
Allow caching for redirect codes

### DIFF
--- a/features/set_cache_time.feature
+++ b/features/set_cache_time.feature
@@ -58,6 +58,19 @@ Feature: Set cache time
     | /some-url                                               |     900 |
     | /favicon.ico                                            |   14400 |
 
+  Scenario Outline: The response from Babbage is 301 so we set Cache-Control header
+    Given Babbage will send the following response with status "301":
+      """
+      """
+    And Babbage will set the "X-Some-Header" header to "some-value"
+    When the Proxy receives a GET request for "<sample-uri>"
+    Then the response header "Cache-Control" should be "public, s-maxage=<max-age>, max-age=<max-age>"
+    And the HTTP status code should be "301"
+  Examples:
+    | sample-uri                                              | max-age |
+    | /some-url                                               |     900 |
+    | /favicon.ico                                            |   14400 |
+
   Scenario: Return the errored cache time when the Legacy Cache API returns an error
     Given the Legacy Cache API has an error
     When the Proxy receives a GET request for "/some-path"

--- a/features/unmodified_response.feature
+++ b/features/unmodified_response.feature
@@ -34,13 +34,9 @@ Feature: Unmodified response
   Examples:
     | status-code |
     | 300         |
-    | 301         |
-    | 302         |
     | 303         |
     | 305         |
     | 306         |
-    | 307         |
-    | 308         |
     | 400         |
     | 401         |
     | 402         |

--- a/response/writer.go
+++ b/response/writer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 
 	"github.com/ONSdigital/dp-legacy-cache-proxy/config"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -86,7 +87,9 @@ func isGetOrHead(method string) bool {
 }
 
 func isCacheableStatusCode(statusCode int) bool {
-	return statusCode < 300 || statusCode == 304 || statusCode == 404
+	cacheableStatusCodeExceptions := []int{301, 302, 304, 307, 308, 404}
+
+	return statusCode < 300 || slices.Contains(cacheableStatusCodeExceptions, statusCode)
 }
 
 func shouldCalculateMaxAge(cacheControlValue string) bool {


### PR DESCRIPTION
### What

Allowed redirects to be cached due to new functionality allowing redirects to be modified at publish time. 

### How to review

Check looks ok. 

### Who can review

Not me. 