### PR TITLE
Release/1.13.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: delimiter-AUDIT audit delimiter-LINTERS lint delimiter-UNIT-TESTS test deli
 
 .PHONY: audit
 audit: ## Runs checks for security vulnerabilities on dependencies (including transient ones)
-	go list -json -m all | nancy sleuth
+	dis-vulncheck
 
 .PHONY: build
 build: ## Builds binary of application code and stores in bin directory as dp-legacy-cache-proxy

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ directives in the `Cache-Control` header to appropriate values.
 
 - No further dependencies other than those defined in `go.mod`
 
+### Tools
+
+To run some of our tests you will need additional tooling:
+
+#### Audit
+
+We use `dis-vulncheck` to do auditing, which you will [need to install](https://github.com/ONSdigital/dis-vulncheck).
+
+#### Linting
+
+We use v2 of golangci-lint, which you will [need to install](https://golangci-lint.run/docs/welcome/install).
+
 ### Configuration
 
 | Environment variable           | Default                   | Description

--- a/ci/audit.yml
+++ b/ci/audit.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: onsdigital/dp-concourse-tools-nancy
+    repository: onsdigital/dp-concourse-tools-vulncheck
     tag: latest
 
 inputs:

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.6-bookworm
+    tag: 1.24.7-bookworm
 
 inputs:
   - name: dp-legacy-cache-proxy

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.6-bookworm
+    tag: 1.24.7-bookworm
 
 inputs:
   - name: dp-legacy-cache-proxy

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.24.6-bookworm-golangci-lint-2
+    tag: 1.24.7-bookworm-golangci-lint-2
 
 inputs:
   - name: dp-legacy-cache-proxy

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.6-bookworm
+    tag: 1.24.7-bookworm
 
 inputs:
   - name: dp-legacy-cache-proxy


### PR DESCRIPTION
### What

- Switch audit tool from nancy to vulncheck
- Bump ci and docker local Go version

### How to review

Check release is okay

### Who can review

!Me
