### PR TITLE
Upgrade go to 1.26.2

### DIFF
--- a/.dis-vulncheck.yml
+++ b/.dis-vulncheck.yml
@@ -1,0 +1,7 @@
+ignore:
+  - id: GO-2026-4883
+    module: github.com/docker/docker
+    reason: No fix available; transitive dependency via dp-component-test -> testcontainers-go; only used for testing, not used by service runtime.
+  - id: GO-2026-4887
+    module: github.com/docker/docker
+    reason: No fix available; transitive dependency via dp-component-test -> testcontainers-go; only used for testing, not used by service runtime.

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.1-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dp-legacy-cache-proxy

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.1-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dp-legacy-cache-proxy

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.26.1-bookworm-golangci-lint-2
+    tag: 1.26.2-bookworm-golangci-lint-2
 
 inputs:
   - name: dp-legacy-cache-proxy

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.1-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dp-legacy-cache-proxy


### PR DESCRIPTION
### What

The version of go has been increased from 1.26.1 to 1.26.2, to fix audit failures, and a couple of vulnerabilities have been ignored as they cannot be fixed at the moment and they're only used for testing.

### How to review

Sense check. Tests pass.

### Who can review

Anyone.