### PR TITLE
Release 1.15.0

### DIFF
--- a/.dis-vulncheck.yml
+++ b/.dis-vulncheck.yml
@@ -1,0 +1,7 @@
+ignore:
+  - id: GO-2026-4883
+    module: github.com/docker/docker
+    reason: No fix available; transitive dependency via dp-component-test -> testcontainers-go; only used for testing, not used by service runtime.
+  - id: GO-2026-4887
+    module: github.com/docker/docker
+    reason: No fix available; transitive dependency via dp-component-test -> testcontainers-go; only used for testing, not used by service runtime.

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.1-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dp-legacy-cache-proxy

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.1-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dp-legacy-cache-proxy

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.26.1-bookworm-golangci-lint-2
+    tag: 1.26.2-bookworm-golangci-lint-2
 
 inputs:
   - name: dp-legacy-cache-proxy

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.1-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dp-legacy-cache-proxy


### PR DESCRIPTION
# What has changed
These are the changes in this release:

- [Upgrade go to 1.26.2](https://github.com/ONSdigital/dp-legacy-cache-proxy/pull/80) - @cookel2

# How to review
<!--- Describe in detail how you tested your changes. -->
Check only expected commits present and tests pass

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me